### PR TITLE
Add CMake Build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 
 #Project config
 *.pro.user
+CMakeLists.txt.user
+
+#Build Directories
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,57 @@
+project(QMPlay2)
+cmake_minimum_required(VERSION 3.0.2)
+include(GNUInstallDirs)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(DEFAULT_ALSA ON)
+    set(DEFAULT_PORTAUDIO OFF)
+else()
+    set(DEFAULT_ALSA OFF)
+    set(DEFAULT_PORTAUDIO ON)
+endif()
+
+OPTION(USE_QT5 "Build with Qt5" ON)
+OPTION(USE_TAGLIB "Build with tags editor" ON)
+OPTION(USE_AVRESAMPLE "Build with support for libavresample" OFF)
+
+OPTION(USE_ALSA "Build with ALSA support" ${DEFAULT_ALSA})
+OPTION(USE_AUDIOCD "Build with AudioCD support" ON)
+OPTION(USE_OPENGL "Build with OpenGL support" ON)
+OPTION(USE_PORTAUDIO "Build with PortAudio support" ${DEFAULT_PORTAUDIO})
+OPTION(USE_PULSEAUDIO "Build with PulseAudio support" ON)
+OPTION(USE_XVIDEO "Build with XVideo support" ON)
+
+OPTION(USE_CHIPTUNE_GME "Build Chiptune with GME support" ON)
+OPTION(USE_CHIPTUNE_SID "Build Chiptune with SIDPLAY support" ON)
+
+OPTION(USE_FFMPEG_VAAPI "Build VAAPI acceleration into FFmpeg" ON)
+OPTION(USE_FFMPEG_VDPAU "Build VDPAU acceleration into FFmpeg" ON)
+OPTION(USE_FFMPEG_AVDEVICE "Build FFmpeg with libavdevice suport" ON)
+
+set(LANGUAGES "All" CACHE STRING "A space-seperated list of translations to compile in to QMPlay2, or \"None\", or \"All\".")
+
+# set default build as Release
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+# get QMPLAY2_VERSION by running the version script
+execute_process(
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/version
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE QMPLAY2_VERSION)
+string(STRIP ${QMPLAY2_VERSION} QMPLAY2_VERSION)
+
+add_subdirectory(src)
+add_subdirectory(lang)
+
+install(FILES ChangeLog DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/qmplay2/)
+
+# uninstall target
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Changes in QMPlay2 build 16.06.14:
 	- fixed color in graphics subtitles (e.g. dvdsub),
 	- hide mouse cursor when cover image is visible,
 	- updated Russian translation (victorr2007),
+	- added CMake build (Zamarin Arthur),
 	- show more information to the user,
 	- bugfix,
 

--- a/compile_unix
+++ b/compile_unix
@@ -70,8 +70,8 @@ else
 		VERSION=$(./version)
 		if [ $? == 0 ]; then
 			mkdir -p app/share/man/man1
-			cp src/gui/Unix/QMPlay2.1 app/share/man/man1
-			sed -i "s/VERSION/$VERSION/" app/share/man/man1/QMPlay2.1
+			cp src/gui/Unix/QMPlay2.1.in app/share/man/man1/QMPlay2.1
+			sed -i "s/@QMPLAY2_VERSION@/$VERSION/" app/share/man/man1/QMPlay2.1
 			gzip -f app/share/man/man1/QMPlay2.1
 		fi
 	fi

--- a/lang/CMakeLists.txt
+++ b/lang/CMakeLists.txt
@@ -1,0 +1,29 @@
+project(langs)
+cmake_minimum_required(VERSION 3.0.2)
+include(GNUInstallDirs)
+
+if(LANGUAGES STREQUAL "All")
+    # build LANGUAGES from all existing .ts files
+    file(GLOB QMPLAY2_TSS *.ts)
+elseif(NOT LANGUAGES OR LANGUAGES STREQUAL "None")
+    set (QMPLAY2_TSS "")
+else()
+    string(REGEX MATCHALL [a-zA-Z_@]+
+           LANGUAGES_TR ${LANGUAGES})
+    set(QMPLAY2_TSS "")
+    foreach(LANG ${LANGUAGES_TR})
+       LIST(APPEND QMPLAY2_TSS "${LANG}.ts")
+    endforeach()
+endif ()
+
+if(USE_QT5)
+    find_package(Qt5LinguistTools REQUIRED)
+    qt5_add_translation(QM_FILES ${QMPLAY2_TSS})
+else()
+    find_package(Qt4 REQUIRED)
+    qt4_add_translation(QM_FILES ${QMPLAY2_TSS})
+endif()
+
+add_custom_target(translations ALL DEPENDS ${QM_FILES})
+
+install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/qmplay2/lang/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+if(USE_QT5)
+    find_package(Qt5Widgets REQUIRED)
+    if(Qt5Widgets_VERSION LESS 5.6.1)
+        message(AUTHOR_WARNING "Qt5 >= 5.6.1 is recommended for stable usage")
+    endif()
+else()
+    find_package(Qt4 REQUIRED)
+    include("${QT_USE_FILE}")
+    add_definitions(${QT_DEFINITIONS})
+endif()
+
+add_subdirectory(gui)
+add_subdirectory(qmplay2)
+add_subdirectory(modules)

--- a/src/cmake_uninstall.cmake.in
+++ b/src/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,0 +1,136 @@
+project(gui)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+include(GNUInstallDirs)
+
+set(GUI_HDR
+    Main.hpp
+    MenuBar.hpp
+    MainWidget.hpp
+    AddressBox.hpp
+    VideoDock.hpp
+    InfoDock.hpp
+    PlaylistDock.hpp
+    PlayClass.hpp
+    DemuxerThr.hpp
+    AVThread.hpp
+    VideoThr.hpp
+    AudioThr.hpp
+    SettingsWidget.hpp
+    OSDSettingsW.hpp
+    DeintSettingsW.hpp
+    OtherVFiltersW.hpp
+    PlaylistWidget.hpp
+    EntryProperties.hpp
+    AboutWidget.hpp
+    AddressDialog.hpp
+    VideoEqualizer.hpp
+    Appearance.hpp
+    VolWidget.hpp
+)
+
+set(GUI_SRC
+    Main.cpp
+    MenuBar.cpp
+    MainWidget.cpp
+    AddressBox.cpp
+    VideoDock.cpp
+    InfoDock.cpp
+    PlaylistDock.cpp
+    PlayClass.cpp
+    DemuxerThr.cpp
+    AVThread.cpp
+    VideoThr.cpp
+    AudioThr.cpp
+    SettingsWidget.cpp
+    OSDSettingsW.cpp
+    DeintSettingsW.cpp
+    OtherVFiltersW.cpp
+    PlaylistWidget.cpp
+    EntryProperties.cpp
+    AboutWidget.cpp
+    AddressDialog.cpp
+    VideoEqualizer.cpp
+    Appearance.cpp
+    VolWidget.cpp
+)
+
+set(GUI_FORMS # *.ui files
+
+)
+
+set(GUI_RESOURCES
+    resources.qrc
+)
+
+PKG_CHECK_MODULES(X11 x11 REQUIRED)
+link_directories(${X11_LIBRARY_DIRS})
+
+if(USE_TAGLIB)
+    add_definitions(-DQMPlay2_TagEditor)
+    list(APPEND GUI_HDR TagEditor.hpp)
+    list(APPEND GUI_SRC TagEditor.cpp)
+    PKG_CHECK_MODULES(TAGLIB taglib REQUIRED)
+    include_directories(${TAGLIB_INCLUDE_DIRS})
+    link_directories(${TAGLIB_LIBRARY_DIRS})
+endif()
+
+if(USE_QT5)
+    qt5_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
+    qt5_add_resources(GUI_RESOURCES_RCC ${GUI_RESOURCES})
+    add_definitions(-DX11_EXTRAS)
+else()
+    qt4_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
+    qt4_add_resources(GUI_RESOURCES_RCC ${GUI_RESOURCES})
+endif()
+
+include_directories(
+    ../qmplay2/headers
+    ${X11_INCLUDE_DIRS}
+)
+
+add_executable(QMPlay2
+    ${GUI_HDR}
+    ${GUI_SRC}
+    ${GUI_FORM_HDR}
+    ${GUI_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(QMPlay2 Gui Widgets Network X11Extras)
+else()
+    target_link_libraries(QMPlay2 Qt4::QtGui Qt4::QtCore Qt4::QtNetwork)
+endif()
+
+add_dependencies(QMPlay2 qmplay2)
+target_link_libraries(QMPlay2
+    ${X11_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+if(USE_TAGLIB)
+    target_link_libraries(QMPlay2 ${TAGLIB_LIBRARIES})
+endif()
+
+install(TARGETS QMPlay2 RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# desktop files
+file(GLOB DESKTOP_FILES Unix/QMPlay2*.desktop)
+install(FILES ${DESKTOP_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/applications/)
+
+# mime files
+file(GLOB MIME_FILES Unix/x-*.xml)
+install(FILES ${MIME_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/mime/packages/)
+
+install(FILES Icons/QMPlay2.png DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps)
+
+# man page
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Unix/QMPlay2.1.in ${CMAKE_CURRENT_BINARY_DIR}/QMPlay2.1 @ONLY)
+find_program(GZIP gzip)
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/QMPlay2.1.gz
+    COMMAND ${GZIP} -c ${CMAKE_CURRENT_BINARY_DIR}/QMPlay2.1 > QMPlay2.1.gz
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/QMPlay2.1)
+add_custom_target(man ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/QMPlay2.1.gz)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QMPlay2.1.gz
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_MANDIR}/man1/)

--- a/src/gui/Unix/QMPlay2.1.in
+++ b/src/gui/Unix/QMPlay2.1.in
@@ -1,4 +1,4 @@
-.TH "QMPlay2" "1" "VERSION" "Dmitriy A. Perlow aka DAP-DarkneSS" ""
+.TH "QMPlay2" "1" "@QMPLAY2_VERSION@" "Dmitriy A. Perlow aka DAP-DarkneSS" ""
 .SH "NAME"
 QMPlay2 — Qt Media Player 2
 .br

--- a/src/modules/ALSA/CMakeLists.txt
+++ b/src/modules/ALSA/CMakeLists.txt
@@ -1,0 +1,50 @@
+project(ALSA)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(ALSA_HDR
+    ALSA.hpp
+    ALSACommon.hpp
+    ALSAWriter.hpp
+)
+
+set(ALSA_SRC
+    ALSA.cpp
+    ALSACommon.cpp
+    ALSAWriter.cpp
+)
+
+set(ALSA_RESOURCES
+    icon.qrc
+)
+
+PKG_CHECK_MODULES(ALSA alsa REQUIRED)
+link_directories(${ALSA_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(ALSA_RESOURCES_RCC ${ALSA_RESOURCES})
+else()
+    qt4_add_resources(ALSA_RESOURCES_RCC ${ALSA_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${ALSA_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${ALSA_HDR}
+    ${ALSA_SRC}
+    ${ALSA_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${ALSA_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/AudioCD/CMakeLists.txt
+++ b/src/modules/AudioCD/CMakeLists.txt
@@ -1,0 +1,50 @@
+project(AudioCD)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(AudioCD_HDR
+    AudioCD.hpp
+    AudioCDDemux.hpp
+)
+
+set(AudioCD_SRC
+    AudioCD.cpp
+    AudioCDDemux.cpp
+)
+
+set(AudioCD_RESOURCES
+    icon.qrc
+)
+
+PKG_CHECK_MODULES(LIBCDIO libcdio REQUIRED)
+PKG_CHECK_MODULES(LIBCDDB libcddb REQUIRED)
+link_directories(${LIBCDIO_LIBRARY_DIRS} ${LIBCDDB_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(AudioCD_RESOURCES_RCC ${AudioCD_RESOURCES})
+else()
+    qt4_add_resources(AudioCD_RESOURCES_RCC ${AudioCD_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${LIBCDIO_INCLUDE_DIRS} ${LIBCDDB_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${AudioCD_HDR}
+    ${AudioCD_SRC}
+    ${AudioCD_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBCDIO_LIBRARIES}
+    ${LIBCDDB_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/AudioFilters/CMakeLists.txt
+++ b/src/modules/AudioFilters/CMakeLists.txt
@@ -1,0 +1,60 @@
+project(AudioFilters)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(AudioFilters_HDR
+    AudioFilters.hpp
+    Equalizer.hpp
+    EqualizerGUI.hpp
+    VoiceRemoval.hpp
+    PhaseReverse.hpp
+    Echo.hpp
+)
+
+set(AudioFilters_SRC
+    AudioFilters.cpp
+    Equalizer.cpp
+    EqualizerGUI.cpp
+    VoiceRemoval.cpp
+    PhaseReverse.cpp
+    Echo.cpp
+)
+
+set(AudioFilters_RESOURCES
+    icons.qrc
+)
+
+add_definitions(-D__STDC_CONSTANT_MACROS)
+
+PKG_CHECK_MODULES(LIBAVCODEC libavcodec REQUIRED)
+PKG_CHECK_MODULES(LIBAVUTIL libavutil REQUIRED)
+link_directories(${LIBAVCODEC_LIBRARY_DIRS} ${LIBAVUTIL_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(AudioFilters_RESOURCES_RCC ${AudioFilters_RESOURCES})
+else()
+    qt4_add_resources(AudioFilters_RESOURCES_RCC ${AudioFilters_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${LIBAVCODEC_INCLUDE_DIRS} ${LIBAVUTIL_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${AudioFilters_HDR}
+    ${AudioFilters_SRC}
+    ${AudioFilters_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBAVCODEC_LIBRARIES}
+    ${LIBAVUTIL_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.0.2)
+
+include(GNUInstallDirs)
+set(MODULES_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/qmplay2/modules/")
+
+if(USE_PORTAUDIO)
+    add_subdirectory(PortAudio)
+endif()
+
+if(USE_ALSA)
+    add_subdirectory(ALSA)
+endif()
+
+if(USE_PULSEAUDIO)
+    add_subdirectory(PulseAudio)
+endif()
+
+if(USE_XVIDEO)
+    add_subdirectory(XVideo)
+endif()
+
+if(USE_AUDIOCD)
+    add_subdirectory(AudioCD)
+endif()
+
+add_subdirectory(AudioFilters)
+add_subdirectory(Extensions)
+add_subdirectory(FFmpeg)
+add_subdirectory(Inputs)
+add_subdirectory(Modplug)
+add_subdirectory(Playlists)
+add_subdirectory(QPainter)
+add_subdirectory(Subtitles)
+add_subdirectory(VideoFilters)
+add_subdirectory(Visualizations)
+
+if(USE_OPENGL)
+    add_subdirectory(OpenGL2)
+endif()
+
+if(USE_CHIPTUNE_GME OR USE_CHIPTUNE_SID)
+    add_subdirectory(Chiptune)
+endif()
+

--- a/src/modules/Chiptune/CMakeLists.txt
+++ b/src/modules/Chiptune/CMakeLists.txt
@@ -1,0 +1,66 @@
+project(Chiptune)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(Chiptune_HDR
+    Chiptune.hpp
+)
+
+set(Chiptune_SRC
+    Chiptune.cpp
+)
+
+set(Chiptune_RESOURCES
+    icon.qrc
+)
+
+set(Chiptune_LIBS
+)
+
+if(USE_CHIPTUNE_GME)
+    PKG_CHECK_MODULES(LIBGME libgme REQUIRED)
+    list(APPEND Chiptune_HDR GME.hpp)
+    list(APPEND Chiptune_SRC GME.cpp)
+    add_definitions(-DUSE_GME)
+    include_directories(${LIBGME_INCLUDE_DIRS})
+    link_directories(${LIBGME_LIBRARY_DIRS})
+    list(APPEND Chiptune_LIBS ${LIBGME_LIBRARIES})
+endif()
+
+if(USE_CHIPTUNE_SID)
+    PKG_CHECK_MODULES(LIBSIDPLAYFP libsidplayfp REQUIRED)
+    list(APPEND Chiptune_HDR SIDPlay.hpp)
+    list(APPEND Chiptune_SRC SIDPlay.cpp)
+    add_definitions(-DUSE_SIDPLAY)
+    include_directories(${LIBSIDPLAYFP_INCLUDE_DIRS})
+    link_directories(${LIBSIDPLAYFP_LIBRARY_DIRS})
+    list(APPEND Chiptune_LIBS ${LIBSIDPLAYFP_LIBRARIES})
+endif()
+
+if(USE_QT5)
+    qt5_add_resources(Chiptune_RESOURCES_RCC ${Chiptune_RESOURCES})
+else()
+    qt4_add_resources(Chiptune_RESOURCES_RCC ${Chiptune_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${Chiptune_HDR}
+    ${Chiptune_SRC}
+    ${Chiptune_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${Chiptune_LIBS}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/Extensions/CMakeLists.txt
+++ b/src/modules/Extensions/CMakeLists.txt
@@ -1,0 +1,55 @@
+project(Extensions)
+cmake_minimum_required(VERSION 3.0.2)
+
+set(Extensions_HDR
+    Extensions.hpp
+    YouTube.hpp
+    Downloader.hpp
+    Radio.hpp
+    LastFM.hpp
+    ProstoPleer.hpp
+    MPRIS2.hpp
+)
+
+set(Extensions_SRC
+    Extensions.cpp
+    YouTube.cpp
+    Downloader.cpp
+    Radio.cpp
+    LastFM.cpp
+    ProstoPleer.cpp
+    MPRIS2.cpp
+)
+
+set(Extensions_RESOURCES
+    icons.qrc
+)
+
+add_definitions(-DUSE_MPRIS2)
+
+if(USE_QT5)
+    qt5_add_resources(Extensions_RESOURCES_RCC ${Extensions_RESOURCES})
+else()
+    qt4_add_resources(Extensions_RESOURCES_RCC ${Extensions_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${Extensions_HDR}
+    ${Extensions_SRC}
+    ${Extensions_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets DBus Network)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtCore Qt4::QtGui Qt4::QtDBus Qt4::QtNetwork)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/FFmpeg/CMakeLists.txt
+++ b/src/modules/FFmpeg/CMakeLists.txt
@@ -1,0 +1,110 @@
+project(FFmpeg)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(FFmpeg_HDR
+    FFmpeg.hpp
+    FFDemux.hpp
+    FFDec.hpp
+    FFDecSW.hpp
+    FFReader.hpp
+    FFCommon.hpp
+    FormatContext.hpp
+)
+
+set(FFmpeg_SRC
+    FFmpeg.cpp
+    FFDemux.cpp
+    FFDec.cpp
+    FFDecSW.cpp
+    FFReader.cpp
+    FFCommon.cpp
+    FormatContext.cpp
+)
+
+set(FFmpeg_RESOURCES
+    icons.qrc
+)
+
+PKG_CHECK_MODULES(LIBAVFORMAT libavformat REQUIRED)
+PKG_CHECK_MODULES(LIBAVCODEC libavcodec REQUIRED)
+PKG_CHECK_MODULES(LIBSWSCALE libswscale REQUIRED)
+PKG_CHECK_MODULES(LIBAVUTIL libavutil REQUIRED)
+link_directories(
+    ${LIBAVFORMAT_LIBRARY_DIRS}
+    ${LIBAVCODEC_LIBRARY_DIRS}
+    ${LIBSWSCALE_LIBRARY_DIRS}
+    ${LIBAVUTIL_LIBRARY_DIRS}
+)
+
+set(FFmpeg_LIBS
+    ${LIBAVFORMAT_LIBRARIES}
+    ${LIBAVCODEC_LIBRARIES}
+    ${LIBSWSCALE_LIBRARIES}
+    ${LIBAVUTIL_LIBRARIES}
+)
+
+add_definitions(-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS)
+
+if(USE_FFMPEG_AVDEVICE) # Common HWAccel
+    add_definitions(-DQMPlay2_libavdevice)
+    list(APPEND FFmpeg_HDR FFDecHWAccel.hpp HWAccelHelper.hpp)
+    list(APPEND FFmpeg_SRC FFDecHWAccel.cpp HWAccelHelper.cpp)
+    PKG_CHECK_MODULES(LIBAVDEVICE libavdevice REQUIRED)
+    include_directories(${LIBAVDEVICE_INCLUDE_DIRS})
+    link_directories(${LIBAVDEVICE_LIBRARY_DIRS})
+    list(APPEND FFmpeg_LIBS ${LIBAVDEVICE_LIBRARIES})
+endif()
+
+if(USE_FFMPEG_VAAPI) # VAAPI
+    add_definitions(-DQMPlay2_VAAPI)
+    list(APPEND FFmpeg_HDR FFDecVAAPI.hpp VAAPIWriter.hpp)
+    list(APPEND FFmpeg_SRC FFDecVAAPI.cpp VAAPIWriter.cpp)
+    PKG_CHECK_MODULES(LIBS_VAAPI libva libva-x11 REQUIRED)
+    include_directories(${LIBS_VAAPI_INCLUDE_DIRS})
+    link_directories(${LIBS_VAAPI_LIBRARY_DIRS})
+    list(APPEND FFmpeg_LIBS ${LIBS_VAAPI_LIBRARIES})
+endif()
+
+if(USE_FFMPEG_VDPAU) # VDPAU
+    add_definitions(-DQMPlay2_VDPAU)
+    list(APPEND FFmpeg_HDR FFDecVDPAU.hpp VDPAUWriter.hpp FFDecVDPAU_NW.hpp)
+    list(APPEND FFmpeg_SRC FFDecVDPAU.cpp VDPAUWriter.cpp FFDecVDPAU_NW.cpp)
+    PKG_CHECK_MODULES(LIBS_VDPAU vdpau REQUIRED)
+    include_directories(${LIBS_VDPAU_INCLUDE_DIRS})
+    link_directories(${LIBS_VDPAU_LIBRARY_DIRS})
+    list(APPEND FFmpeg_LIBS ${LIBS_VDPAU_LIBRARIES})
+endif()
+
+if(USE_QT5)
+    qt5_add_resources(FFmpeg_RESOURCES_RCC ${FFmpeg_RESOURCES})
+else()
+    qt4_add_resources(FFmpeg_RESOURCES_RCC ${FFmpeg_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers
+    ${LIBAVFORMAT_INCLUDE_DIRS}
+    ${LIBAVCODEC_INCLUDE_DIRS}
+    ${LIBSWSCALE_INCLUDE_DIRS}
+    ${LIBAVUTIL_INCLUDE_DIRS}
+)
+
+add_library(${PROJECT_NAME} MODULE
+    ${FFmpeg_HDR}
+    ${FFmpeg_SRC}
+    ${FFmpeg_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets Network)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore Qt4::QtNetwork)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${FFmpeg_LIBS}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/Inputs/CMakeLists.txt
+++ b/src/modules/Inputs/CMakeLists.txt
@@ -1,0 +1,47 @@
+project(Inputs)
+cmake_minimum_required(VERSION 3.0.2)
+
+set(Inputs_HDR
+    Inputs.hpp
+    ToneGenerator.hpp
+    PCM.hpp
+    Rayman2.hpp
+)
+
+set(Inputs_SRC
+    Inputs.cpp
+    ToneGenerator.cpp
+    PCM.cpp
+    Rayman2.cpp
+)
+
+set(Inputs_RESOURCES
+    icons.qrc
+)
+
+if(USE_QT5)
+    qt5_add_resources(Inputs_RESOURCES_RCC ${Inputs_RESOURCES})
+else()
+    qt4_add_resources(Inputs_RESOURCES_RCC ${Inputs_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${Inputs_HDR}
+    ${Inputs_SRC}
+    ${Inputs_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/Modplug/CMakeLists.txt
+++ b/src/modules/Modplug/CMakeLists.txt
@@ -1,0 +1,65 @@
+project(Modplug)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(Modplug_HDR
+    Modplug.hpp
+    MPDemux.hpp
+)
+
+set(Modplug_SRC
+    Modplug.cpp
+    MPDemux.cpp
+
+    libmodplug/fastmix.cpp
+    libmodplug/load_ams.cpp
+    libmodplug/load_dsm.cpp
+    libmodplug/load_j2b.cpp
+    libmodplug/load_mod.cpp
+    libmodplug/load_okt.cpp
+    libmodplug/load_s3m.cpp
+    libmodplug/load_umx.cpp
+    libmodplug/orig_modplug.cpp
+    libmodplug/snd_flt.cpp
+    libmodplug/load_669.cpp
+    libmodplug/load_dbm.cpp
+    libmodplug/load_far.cpp
+    libmodplug/load_mdl.cpp
+    libmodplug/load_mt2.cpp
+    libmodplug/load_psm.cpp
+    libmodplug/load_stm.cpp
+    libmodplug/load_xm.cpp
+    libmodplug/snd_dsp.cpp
+    libmodplug/snd_fx.cpp
+    libmodplug/load_amf.cpp
+    libmodplug/load_dmf.cpp
+    libmodplug/load_it.cpp
+    libmodplug/load_med.cpp
+    libmodplug/load_mtm.cpp
+    libmodplug/load_ptm.cpp
+    libmodplug/load_ult.cpp
+    libmodplug/load_sfx.cpp
+    libmodplug/mmcmp.cpp
+    libmodplug/sndfile.cpp
+    libmodplug/sndmix.cpp
+)
+
+include_directories(../../qmplay2/headers libmodplug)
+
+add_library(${PROJECT_NAME} MODULE
+    ${Modplug_HDR}
+    ${Modplug_SRC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/OpenGL2/CMakeLists.txt
+++ b/src/modules/OpenGL2/CMakeLists.txt
@@ -1,0 +1,64 @@
+project(OpenGL2)
+cmake_minimum_required(VERSION 3.0.2)
+
+set(OpenGL2_HDR
+    OpenGL2.hpp
+    OpenGL2Writer.hpp
+    OpenGL2Common.hpp
+    Sphere.hpp
+    Shaders.hpp
+    Vertices.hpp
+)
+
+set(OpenGL2_SRC
+    OpenGL2.cpp
+    OpenGL2Writer.cpp
+    OpenGL2Common.cpp
+    Sphere.cpp
+)
+
+set(OpenGL2_RESOURCES
+    icon.qrc
+)
+
+if(NOT USE_QT5 OR Qt5Widgets_VERSION LESS 5.6.0)
+    add_definitions(-DDONT_RECREATE_SHADERS)
+    list(APPEND OpenGL2_HDR OpenGL2OldWidget.hpp)
+    list(APPEND OpenGL2_SRC OpenGL2OldWidget.cpp)
+
+    # add check for opengles2 in QT_CONFIG
+    add_definitions(-DVSYNC_SETTINGS)
+else()
+    add_definitions(-DOPENGL_NEW_API -DVSYNC_SETTINGS)
+    list(APPEND OpenGL2_HDR OpenGL2Window.hpp OpenGL2Widget.hpp OpenGL2CommonQt5.hpp)
+    list(APPEND OpenGL2_SRC OpenGL2Window.cpp OpenGL2Widget.cpp OpenGL2CommonQt5.cpp)
+endif()
+
+if(USE_QT5)
+    qt5_add_resources(OpenGL2_RESOURCES_RCC ${OpenGL2_RESOURCES})
+else()
+    qt4_add_resources(OpenGL2_RESOURCES_RCC ${OpenGL2_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${OpenGL2_HDR}
+    ${OpenGL2_SRC}
+    ${OpenGL2_RESOURCES_RCC}
+)
+
+if(NOT USE_QT5) # Qt4
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore Qt4::QtOpenGL)
+elseif(Qt5Widgets_VERSION LESS 5.6.0) # Qt5 < 5.6.0
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets OpenGL)
+else() # Qt5 >= 5.6.0
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/Playlists/CMakeLists.txt
+++ b/src/modules/Playlists/CMakeLists.txt
@@ -1,0 +1,34 @@
+project(Playlists)
+cmake_minimum_required(VERSION 3.0.2)
+
+set(Playlists_HDR
+    Playlists.hpp
+    PLS.hpp
+    M3U.hpp
+)
+
+set(Playlists_SRC
+    Playlists.cpp
+    PLS.cpp
+    M3U.cpp
+)
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${Playlists_HDR}
+    ${Playlists_SRC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/PortAudio/CMakeLists.txt
+++ b/src/modules/PortAudio/CMakeLists.txt
@@ -1,0 +1,50 @@
+project(PortAudio)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(PortAudio_HDR
+    PortAudio.hpp
+    PortAudioCommon.hpp
+    PortAudioWriter.hpp
+)
+
+set(PortAudio_SRC
+    PortAudio.cpp
+    PortAudioCommon.cpp
+    PortAudioWriter.cpp
+)
+
+set(PortAudio_RESOURCES
+    icon.qrc
+)
+
+PKG_CHECK_MODULES(LIBPORTAUDIO portaudio-2.0 REQUIRED)
+link_directories(${LIBPORTAUDIO_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(PortAudio_RESOURCES_RCC ${PortAudio_RESOURCES})
+else()
+    qt4_add_resources(PortAudio_RESOURCES_RCC ${PortAudio_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${LIBPORTAUDIO_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${PortAudio_HDR}
+    ${PortAudio_SRC}
+    ${PortAudio_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBPORTAUDIO_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/PulseAudio/CMakeLists.txt
+++ b/src/modules/PulseAudio/CMakeLists.txt
@@ -1,0 +1,50 @@
+project(PulseAudio)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(PulseAudio_HDR
+    PulseAudio.hpp
+    PulseAudioWriter.hpp
+    Pulse.hpp
+)
+
+set(PulseAudio_SRC
+    PulseAudio.cpp
+    PulseAudioWriter.cpp
+    Pulse.cpp
+)
+
+set(PulseAudio_RESOURCES
+    icon.qrc
+)
+
+PKG_CHECK_MODULES(LIBPULSE libpulse-simple REQUIRED)
+link_directories(${LIBPULSE_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(PulseAudio_RESOURCES_RCC ${PulseAudio_RESOURCES})
+else()
+    qt4_add_resources(PulseAudio_RESOURCES_RCC ${PulseAudio_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${LIBPULSE_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${PulseAudio_HDR}
+    ${PulseAudio_SRC}
+    ${PulseAudio_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBPULSE_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/QPainter/CMakeLists.txt
+++ b/src/modules/QPainter/CMakeLists.txt
@@ -1,0 +1,43 @@
+project(QPainter)
+cmake_minimum_required(VERSION 3.0.2)
+
+set(QPainter_HDR
+    QPainterWriter.hpp
+    QPainter.hpp
+)
+
+set(QPainter_SRC
+    QPainterWriter.cpp
+    QPainter.cpp
+)
+
+set(QPainter_RESOURCES
+    icon.qrc
+)
+
+if(USE_QT5)
+    qt5_add_resources(QPainter_RESOURCES_RCC ${QPainter_RESOURCES})
+else()
+    qt4_add_resources(QPainter_RESOURCES_RCC ${QPainter_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${QPainter_HDR}
+    ${QPainter_SRC}
+    ${QPainter_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/Subtitles/CMakeLists.txt
+++ b/src/modules/Subtitles/CMakeLists.txt
@@ -1,0 +1,34 @@
+project(Subtitles)
+cmake_minimum_required(VERSION 3.0.2)
+
+set(Subtitles_HDR
+    SRT.hpp
+    Classic.hpp
+    Subtitles.hpp
+)
+
+set(Subtitles_SRC
+    SRT.cpp
+    Classic.cpp
+    Subtitles.cpp
+)
+
+include_directories(../../qmplay2/headers)
+
+add_library(${PROJECT_NAME} MODULE
+    ${Subtitles_HDR}
+    ${Subtitles_SRC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/VideoFilters/CMakeLists.txt
+++ b/src/modules/VideoFilters/CMakeLists.txt
@@ -1,0 +1,56 @@
+project(VideoFilters)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(VideoFilters_HDR
+    VFilters.hpp
+    BobDeint.hpp
+    BlendDeint.hpp
+    DiscardDeint.hpp
+    MotionBlur.hpp
+    YadifDeint.hpp
+)
+
+set(VideoFilters_SRC
+    VFilters.cpp
+    BobDeint.cpp
+    BlendDeint.cpp
+    DiscardDeint.cpp
+    MotionBlur.cpp
+    YadifDeint.cpp
+)
+
+set(VideoFilters_RESOURCES
+    icons.qrc
+)
+
+PKG_CHECK_MODULES(LIBAVUTIL libavutil REQUIRED)
+link_directories(${LIBAVUTIL_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(VideoFilters_RESOURCES_RCC ${VideoFilters_RESOURCES})
+else()
+    qt4_add_resources(VideoFilters_RESOURCES_RCC ${VideoFilters_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${LIBAVUTIL_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${VideoFilters_HDR}
+    ${VideoFilters_SRC}
+    ${VideoFilters_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBAVUTIL_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/Visualizations/CMakeLists.txt
+++ b/src/modules/Visualizations/CMakeLists.txt
@@ -1,0 +1,45 @@
+project(Visualizations)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(Visualizations_HDR
+    Visualizations.hpp
+    SimpleVis.hpp
+    FFTSpectrum.hpp
+    VisWidget.hpp
+)
+
+set(Visualizations_SRC
+    Visualizations.cpp
+    SimpleVis.cpp
+    FFTSpectrum.cpp
+    VisWidget.cpp
+)
+
+add_definitions(-D__STDC_CONSTANT_MACROS)
+
+PKG_CHECK_MODULES(LIBAVUTIL libavutil REQUIRED)
+PKG_CHECK_MODULES(LIBAVCODEC libavcodec REQUIRED)
+link_directories(${LIBAVCODEC_LIBRARY_DIRS} ${LIBAVUTIL_LIBRARY_DIRS})
+
+include_directories(../../qmplay2/headers ${LIBAVUTIL_INCLUDE_DIRS} ${LIBAVCODEC_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${Visualizations_HDR}
+    ${Visualizations_SRC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBAVUTIL_LIBRARIES}
+    ${LIBAVCODEC_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/modules/XVideo/CMakeLists.txt
+++ b/src/modules/XVideo/CMakeLists.txt
@@ -1,0 +1,50 @@
+project(XVideo)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(XVideo_HDR
+    XVideoWriter.hpp
+    XVideo.hpp
+    xv.hpp
+)
+
+set(XVideo_SRC
+    XVideoWriter.cpp
+    XVideo.cpp
+    xv.cpp
+)
+
+set(XVideo_RESOURCES
+    icon.qrc
+)
+
+PKG_CHECK_MODULES(LIBX11 xv x11 REQUIRED)
+link_directories(${LIBX11_LIBRARY_DIRS})
+
+if(USE_QT5)
+    qt5_add_resources(XVideo_RESOURCES_RCC ${XVideo_RESOURCES})
+else()
+    qt4_add_resources(XVideo_RESOURCES_RCC ${XVideo_RESOURCES})
+endif()
+
+include_directories(../../qmplay2/headers ${LIBX11_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME} MODULE
+    ${XVideo_HDR}
+    ${XVideo_SRC}
+    ${XVideo_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets X11Extras)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+add_dependencies(${PROJECT_NAME} qmplay2)
+target_link_libraries(${PROJECT_NAME}
+    ${LIBX11_LIBRARIES}
+    $<TARGET_FILE:qmplay2>
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION "${MODULES_INSTALL_PATH}")

--- a/src/qmplay2/CMakeLists.txt
+++ b/src/qmplay2/CMakeLists.txt
@@ -1,0 +1,147 @@
+project(qmplay2)
+cmake_minimum_required(VERSION 3.0.2)
+FIND_PACKAGE(PkgConfig REQUIRED)
+
+set(QMPLAY2_HDR
+    headers/QMPlay2Core.hpp
+    headers/Functions.hpp
+    headers/Settings.hpp
+    headers/Module.hpp
+    headers/ModuleParams.hpp
+    headers/ModuleCommon.hpp
+    headers/Playlist.hpp
+    headers/Reader.hpp
+    headers/Demuxer.hpp
+    headers/Decoder.hpp
+    headers/VideoFilters.hpp
+    headers/VideoFilter.hpp
+    headers/DeintFilter.hpp
+    headers/AudioFilter.hpp
+    headers/Writer.hpp
+    headers/QMPlay2Extensions.hpp
+    headers/LineEdit.hpp
+    headers/Slider.hpp
+    headers/QMPlay2_OSD.hpp
+    headers/InDockW.hpp
+    headers/LibASS.hpp
+    headers/ColorButton.hpp
+    headers/ImgScaler.hpp
+    headers/SndResampler.hpp
+    headers/VideoWriter.hpp
+    headers/SubsDec.hpp
+    headers/ByteArray.hpp
+    headers/TimeStamp.hpp
+    headers/Packet.hpp
+    headers/VideoFrame.hpp
+    headers/StreamInfo.hpp
+    headers/DockWidget.hpp
+    headers/IOController.hpp
+    headers/ChapterInfo.hpp
+    headers/PacketBuffer.hpp
+    headers/Buffer.hpp
+    headers/CPU.hpp
+    headers/Version.hpp
+    headers/PixelFormats.hpp
+)
+
+set(QMPLAY2_SRC
+    QMPlay2Core.cpp
+    Functions.cpp
+    Settings.cpp
+    Module.cpp
+    ModuleParams.cpp
+    ModuleCommon.cpp
+    Playlist.cpp
+    Reader.cpp
+    Demuxer.cpp
+    Decoder.cpp
+    VideoFilters.cpp
+    VideoFilter.cpp
+    DeintFilter.cpp
+    AudioFilter.cpp
+    Writer.cpp
+    QMPlay2Extensions.cpp
+    LineEdit.cpp
+    Slider.cpp
+    QMPlay2_OSD.cpp
+    InDockW.cpp
+    LibASS.cpp
+    ColorButton.cpp
+    ImgScaler.cpp
+    SndResampler.cpp
+    VideoWriter.cpp
+    SubsDec.cpp
+    VideoFrame.cpp
+    StreamInfo.cpp
+    DockWidget.cpp
+    PacketBuffer.cpp
+    Buffer.cpp
+)
+
+set(QMPLAY2_RESOURCES
+    languages.qrc
+)
+
+PKG_CHECK_MODULES(LIBSWSCALE libswscale REQUIRED)
+PKG_CHECK_MODULES(LIBAVUTIL libavutil REQUIRED)
+PKG_CHECK_MODULES(LIBASS libass REQUIRED)
+
+link_directories(
+    ${LIBSWSCALE_LIBRARY_DIRS}
+    ${LIBAVUTIL_LIBRARY_DIRS}
+    ${LIBASS_LIBRARY_DIRS}
+)
+
+set(QMPLAY2_LIBS
+    ${LIBSWSCALE_LIBRARIES}
+    ${LIBAVUTIL_LIBRARIES}
+    ${LIBASS_LIBRARIES}
+)
+
+include_directories(
+    headers
+    ${LIBSWSCALE_INCLUDE_DIRS}
+    ${LIBAVUTIL_INCLUDE_DIRS}
+    ${LIBASS_INCLUDE_DIRS}
+)
+
+if(USE_AVRESAMPLE)
+    add_definitions(-DQMPLAY2_AVRESAMPLE)
+    PKG_CHECK_MODULES(LIBAVRESAMPLE libavresample REQUIRED)
+    list(APPEND QMPLAY2_LIBS ${LIBAVRESAMPLE_LIBRARIES})
+    include_directories(${LIBAVRESAMPLE_INCLUDE_DIRS})
+    link_directories(${LIBAVRESAMPLE_LIBRARY_DIRS})
+else()
+    PKG_CHECK_MODULES(LIBSWRESAMPLE libswresample REQUIRED)
+    list(APPEND QMPLAY2_LIBS ${LIBSWRESAMPLE_LIBRARIES})
+    include_directories(${LIBSWRESAMPLE_INCLUDE_DIRS})
+    link_directories(${LIBSWRESAMPLE_LIBRARY_DIRS})
+endif()
+
+if(USE_QT5)
+    qt5_add_resources(QMPLAY2_RESOURCES_RCC ${QMPLAY2_RESOURCES})
+else()
+    qt4_add_resources(QMPLAY2_RESOURCES_RCC ${QMPLAY2_RESOURCES})
+endif()
+
+add_definitions(-D__STDC_CONSTANT_MACROS)
+
+add_library(${PROJECT_NAME} SHARED
+    ${QMPLAY2_HDR}
+    ${QMPLAY2_SRC}
+    ${QMPLAY2_RESOURCES_RCC}
+)
+
+if(USE_QT5)
+    qt5_use_modules(${PROJECT_NAME} Gui Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} Qt4::QtGui Qt4::QtCore)
+endif()
+
+target_link_libraries(${PROJECT_NAME}
+    ${QMPLAY2_LIBS}
+)
+
+install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES ${QMPLAY2_HDR} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/QMPlay2)


### PR DESCRIPTION
This is quite a big commit consisting of all the CMake script files of all the project (based on QMake's subdir approach).
I tested building with Qt5 on my main Gentoo system and Qt4 & Qt5 on my Arch Linux system. I hope you have some other distributions so we can check all the possible problems (which I think come to Qt finding problem or pkg-config).

As a user of Gentoo, where I like many options to compile with, I decided to add many compile options, making it much easier to customize the build. All those options with short documentation are found in /CMakeLists.txt file.

In every CMakeLists.txt you will find an array of HDR (headers), SRC (sources) and RESOURCES. If you would like to add some files, just append them in a new line in the appropriate array. Also, in the gui project, I added an empty GUI_FORMS array for all the future *.ui files.

I tried to follow your install & build scripts for UNIX, but maybe I missed some of them. Please tell if you find.

For building, run those commands (after you cd to the root directory of this project):

1. mkdir -p build && cd build
2. cmake ..
3. make -j$(nproc)
4. make DESTDIR=$(pwd)/app install

Those commands will compile all the options (with Qt5) and install after the compilation into the app folder.

I suggest that we fix all the complains and only after them we merge. After we merge this PR, I would like to update the Arch's PKGBUILD and Gentoo's ebuild to use the new CMake.