### PR TITLE
Settings UI files

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -66,6 +66,8 @@ set(GUI_SRC
 
 set(GUI_FORMS # *.ui files
     ui/settings_general.ui
+    ui/settings_playback.ui
+    ui/settings_playback_moduleslist.ui
 )
 
 set(GUI_RESOURCES

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -65,7 +65,7 @@ set(GUI_SRC
 )
 
 set(GUI_FORMS # *.ui files
-
+    ui/settings_general.ui
 )
 
 set(GUI_RESOURCES
@@ -73,12 +73,12 @@ set(GUI_RESOURCES
 )
 
 if(USE_QT5)
-    #qt5_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
+    qt5_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
     qt5_add_resources(GUI_RESOURCES_RCC ${GUI_RESOURCES})
 else()
     find_package(Qt4 REQUIRED QtNetwork)
     include("${QT_USE_FILE}")
-    #qt4_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
+    qt4_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
     qt4_add_resources(GUI_RESOURCES_RCC ${GUI_RESOURCES})
 endif()
 
@@ -135,6 +135,7 @@ endif()
 add_executable(QMPlay2 ${WIN32_EXE}
     ${GUI_HDR}
     ${GUI_SRC}
+    ${GUI_FORM_HDR}
     ${GUI_RESOURCES_RCC}
 )
 

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -407,7 +407,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 		page2_modulesList[m] = ml;
 	}
 
-	/* Strona 3 */
+	/* Page 3 */
 	page3->module = NULL;
 
 	page3->listW = new QListWidget;
@@ -446,7 +446,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 	page3->layout->addWidget(page3->scrollA);
 	connect(page3->listW, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this, SLOT(chModule(QListWidgetItem *)));
 
-	/* Strona 4 */
+	/* Page 4 */
 	page4->colorsAndBordersB = new QCheckBox(tr("Colors and borders"));
 	page4->colorsAndBordersB->setChecked(QMPSettings.getBool("ApplyToASS/ColorsAndBorders"));
 
@@ -472,14 +472,14 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 	page4->layout->addWidget(page4->toASSGB, 2, 0, 1, 5);
 	AddVHSpacer(*page4->layout);
 
-	/* Strona 5 */
+	/* Page 5 */
 	page5->enabledB = new QCheckBox(tr("OSD enabled"));
 	page5->enabledB->setChecked(QMPSettings.getBool("OSD/Enabled"));
 
 	page5->layout->addWidget(page5->enabledB, 2, 0, 1, 5);
 	AddVHSpacer(*page5->layout);
 
-	/* Strona 6 */
+	/* Page 6 */
 	page6->deintSettingsW = new DeintSettingsW;
 
 	page6->otherVFiltersL = new QLabel(tr("Software video filters") + ":");

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -56,6 +56,8 @@
 #include <Module.hpp>
 
 #include "ui_settings_general.h"
+#include "ui_settings_playback.h"
+#include "ui_settings_playback_moduleslist.h"
 
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
 	#define ICONS_FROM_THEME
@@ -64,38 +66,6 @@
 	#include <windows.h>
 #endif
 
-class Page2 : public QWidget
-{
-public:
-	QWidget *w;
-	QScrollArea *scrollA;
-	QGridLayout *layout1;
-	QGridLayout *layout2;
-	QLabel *shortSeekL, *longSeekL, *bufferLocalL, *bufferNetworkL, *backwardBufferNetworkL, *playIfBufferedL, *maxVolL;
-	QSpinBox *shortSeekB, *longSeekB, *bufferLocalB, *bufferNetworkB, *samplerateB, *channelsB, *maxVolB;
-	QComboBox *backwardBufferNetworkB;
-	QDoubleSpinBox *playIfBufferedB;
-	QCheckBox *forceSamplerate, *forceChannels, *showBufferedTimeOnSlider, *savePos, *keepZoom, *keepARatio, *syncVtoA, *keepSubtitlesDelay, *keepSubtitlesScale, *keepVideoDelay, *keepSpeed, *silence, *restoreVideoEq, *ignorePlaybackError;
-
-	QGroupBox *replayGain;
-	QVBoxLayout *replayGainL;
-	QCheckBox *replayGainAlbum, *replayGainPreventClipping;
-	QDoubleSpinBox *replayGainPreamp;
-
-	QGroupBox *wheelActionB;
-	QVBoxLayout *wheelActionL;
-	QRadioButton *wheelSeekB, *wheelVolumeB;
-
-	class ModulesList : public QGroupBox
-	{
-	public:
-		QListWidget *list;
-		QWidget *buttonsW;
-		QToolButton *moveUp, *moveDown;
-		QVBoxLayout *layout1;
-		QHBoxLayout *layout2;
-	} *modulesList[3];
-};
 class Page3 : public QWidget
 {
 public:
@@ -249,7 +219,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 	setWindowFlags(Qt::Window);
 
 	Settings &QMPSettings = QMPlay2Core.getSettings();
-	int idx, layout_row;
+	int idx;
 
 	setWindowTitle(tr("Settings"));
 	setAttribute(Qt::WA_DeleteOnClose);
@@ -260,13 +230,16 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 	page1 = new Ui::GeneralSettings;
 	page1->setupUi(page1_cont);
 
-	page2 = new Page2;
+	QWidget* page2_cont = new QWidget;
+	page2 = new Ui::PlaybackSettings;
+	page2->setupUi(page2_cont);
+
 	page3 = new Page3;
 	page4 = new Page4;
 	page5 = new Page5;
 	page6 = new Page6;
 	tabW->addTab(page1_cont, tr("General settings"));
-	tabW->addTab(page2, tr("Playback settings"));
+	tabW->addTab(page2_cont, tr("Playback settings"));
 	tabW->addTab(page3, tr("Modules"));
 	tabW->addTab(page4, tr("Subtitles"));
 	tabW->addTab(page5, tr("OSD"));
@@ -376,229 +349,63 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 		connect(page1->resetSettingsB, SIGNAL(clicked()), this, SLOT(resetSettings()));
 	}
 
-	/* Strona 2 */
-	page2->shortSeekL = new QLabel(tr("Short seeking (left and right arrows)") + ": ");
-	page2->shortSeekB = new QSpinBox;
-	page2->shortSeekB->setRange(2, 20);
-	page2->shortSeekB->setSuffix(" " + tr("sec"));
+	/* Page 2 */
 	page2->shortSeekB->setValue(QMPSettings.getInt("ShortSeek"));
-
-	page2->longSeekL = new QLabel(tr("Long seeking (up and down arrows)") + ": ");
-	page2->longSeekB = new QSpinBox;
-	page2->longSeekB->setRange(30, 300);
-	page2->longSeekB->setSuffix(" " + tr("sec"));
 	page2->longSeekB->setValue(QMPSettings.getInt("LongSeek"));
-
-	page2->bufferLocalL = new QLabel(tr("Local buffer size (A/V packages count)") + ": ");
-	page2->bufferLocalB = new QSpinBox;
-	page2->bufferLocalB->setRange(1, 1000);
 	page2->bufferLocalB->setValue(QMPSettings.getInt("AVBufferLocal"));
-
-	page2->bufferNetworkL = new QLabel(tr("Network buffer size (A/V packages count)") + ": ");
-	page2->bufferNetworkB = new QSpinBox;
-	page2->bufferNetworkB->setRange(100, 1000000);
 	page2->bufferNetworkB->setValue(QMPSettings.getInt("AVBufferNetwork"));
-
-	page2->backwardBufferNetworkL = new QLabel(tr("Percent of packages for backwards rewinding") + ": ");
-	page2->backwardBufferNetworkB = new QComboBox;
-	page2->backwardBufferNetworkB->addItems(QStringList() << "10%" << "25%" << "50%");
 	page2->backwardBufferNetworkB->setCurrentIndex(QMPSettings.getUInt("BackwardBuffer"));
-
-	page2->playIfBufferedL = new QLabel(tr("Start playback internet stream if it is buffered") + ": ");
-	page2->playIfBufferedB = new QDoubleSpinBox;
-	page2->playIfBufferedB->setRange(0.0, 5.0);
-	page2->playIfBufferedB->setSingleStep(0.25);
-	page2->playIfBufferedB->setSuffix(" " + tr("sec"));
 	page2->playIfBufferedB->setValue(QMPSettings.getDouble("PlayIfBuffered"));
-
-	page2->maxVolL = new QLabel(tr("Maximum volume"));
-	page2->maxVolB = new QSpinBox;
-	page2->maxVolB->setRange(100, 1000);
-	page2->maxVolB->setSingleStep(50);
-	page2->maxVolB->setSuffix(" %");
 	page2->maxVolB->setValue(QMPSettings.getInt("MaxVol"));
 
-	page2->forceSamplerate = new QCheckBox(tr("Force samplerate"));
 	page2->forceSamplerate->setChecked(QMPSettings.getBool("ForceSamplerate"));
-	connect(page2->forceSamplerate, SIGNAL(stateChanged(int)), this, SLOT(page2EnableOrDisable()));
-	page2->samplerateB = new QSpinBox;
-	page2->samplerateB->setRange(4000, 192000);
 	page2->samplerateB->setValue(QMPSettings.getInt("Samplerate"));
+	connect(page2->forceSamplerate, SIGNAL(toggled(bool)), page2->samplerateB, SLOT(setEnabled(bool)));
+	page2->samplerateB->setEnabled(page2->forceSamplerate->isChecked());
 
-	page2->forceChannels = new QCheckBox(tr("Force channels conversion"));
 	page2->forceChannels->setChecked(QMPSettings.getBool("ForceChannels"));
-	connect(page2->forceChannels, SIGNAL(stateChanged(int)), this, SLOT(page2EnableOrDisable()));
-	page2->channelsB = new QSpinBox;
-	page2->channelsB->setRange(1, 8);
 	page2->channelsB->setValue(QMPSettings.getInt("Channels"));
+	connect(page2->forceChannels, SIGNAL(toggled(bool)), page2->channelsB, SLOT(setEnabled(bool)));
+	page2->channelsB->setEnabled(page2->forceChannels->isChecked());
 
-	page2EnableOrDisable();
 
-
-	page2->replayGain = new QGroupBox(tr("Use replay gain if available"));
-	page2->replayGain->setCheckable(true);
 	page2->replayGain->setChecked(QMPSettings.getBool("ReplayGain/Enabled"));
-
-	page2->replayGainL = new QVBoxLayout(page2->replayGain);
-
-	page2->replayGainAlbum = new QCheckBox(tr("Album mode for replay gain"));
 	page2->replayGainAlbum->setChecked(QMPSettings.getBool("ReplayGain/Album"));
-
-	page2->replayGainPreventClipping = new QCheckBox(tr("Prevent clipping"));
 	page2->replayGainPreventClipping->setChecked(QMPSettings.getBool("ReplayGain/PreventClipping"));
-
-	page2->replayGainPreamp = new QDoubleSpinBox;
-	page2->replayGainPreamp->setRange(-15.0, 15.0);
-	page2->replayGainPreamp->setPrefix(tr("Amplify") + ": ");
-	page2->replayGainPreamp->setSuffix(" dB");
 	page2->replayGainPreamp->setValue(QMPSettings.getDouble("ReplayGain/Preamp"));
 
-	page2->replayGainL->addWidget(page2->replayGainAlbum);
-	page2->replayGainL->addWidget(page2->replayGainPreventClipping);
-	page2->replayGainL->addWidget(page2->replayGainPreamp);
-
-
-	page2->wheelActionB = new QGroupBox(tr("Mouse wheel action on video dock"));
-	page2->wheelActionB->setCheckable(true);
 	page2->wheelActionB->setChecked(QMPSettings.getBool("WheelAction"));
-
-	page2->wheelActionL = new QVBoxLayout(page2->wheelActionB);
-
-	page2->wheelSeekB = new QRadioButton(tr("Mouse wheel scrolls music/movie"));
 	page2->wheelSeekB->setChecked(QMPSettings.getBool("WheelSeek"));
-
-	page2->wheelVolumeB = new QRadioButton(tr("Mouse wheel changes the volume"));
 	page2->wheelVolumeB->setChecked(QMPSettings.getBool("WheelVolume"));
 
-	page2->wheelActionL->addWidget(page2->wheelSeekB);
-	page2->wheelActionL->addWidget(page2->wheelVolumeB);
 
-
-	page2->showBufferedTimeOnSlider = new QCheckBox(tr("Show buffered data indicator on slider"));
 	page2->showBufferedTimeOnSlider->setChecked(QMPSettings.getBool("ShowBufferedTimeOnSlider"));
-
-	page2->savePos = new QCheckBox(tr("Remember playback position"));
 	page2->savePos->setChecked(QMPSettings.getBool("SavePos"));
-
-	page2->keepZoom = new QCheckBox(tr("Keep zoom"));;
 	page2->keepZoom->setChecked(QMPSettings.getBool("KeepZoom"));
-
-	page2->keepARatio = new QCheckBox(tr("Keep aspect ratio"));
 	page2->keepARatio->setChecked(QMPSettings.getBool("KeepARatio"));
-
-	page2->keepSubtitlesDelay = new QCheckBox(tr("Keep subtitles delay"));
 	page2->keepSubtitlesDelay->setChecked(QMPSettings.getBool("KeepSubtitlesDelay"));
-
-	page2->keepSubtitlesScale = new QCheckBox(tr("Keep subtitles scale"));
 	page2->keepSubtitlesScale->setChecked(QMPSettings.getBool("KeepSubtitlesScale"));
-
-	page2->keepVideoDelay = new QCheckBox(tr("Keep video delay"));
 	page2->keepVideoDelay->setChecked(QMPSettings.getBool("KeepVideoDelay"));
-
-	page2->keepSpeed = new QCheckBox(tr("Keep speed"));
 	page2->keepSpeed->setChecked(QMPSettings.getBool("KeepSpeed"));
-
-	page2->syncVtoA = new QCheckBox(tr("Video to audio sync (frame skipping)"));
 	page2->syncVtoA->setChecked(QMPSettings.getBool("SyncVtoA"));
-
-	page2->silence = new QCheckBox(tr("Fade sound"));
 	page2->silence->setChecked(QMPSettings.getBool("Silence"));
-
-	page2->restoreVideoEq = new QCheckBox(tr("Remember video equalizer settings"));
 	page2->restoreVideoEq->setChecked(QMPSettings.getBool("RestoreVideoEqualizer"));
-
-	page2->ignorePlaybackError = new QCheckBox(tr("Play next entry after playback error"));
 	page2->ignorePlaybackError->setChecked(QMPSettings.getBool("IgnorePlaybackError"));
 
-	for (int m = 0; m < 3; ++m)
+	QString modules_title_list[3] = {tr("Video output priority"),
+									 tr("Audio output priority"),
+									 tr("Decoders priority")};
+	for(int m = 0; m < 3; ++m)
 	{
-		Page2::ModulesList *&mL = page2->modulesList[m];
-		mL = new Page2::ModulesList;
-
-		mL->list = new QListWidget;
-		mL->list->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred));
-		connect(mL->list, SIGNAL(itemDoubleClicked (QListWidgetItem *)), this, SLOT(openModuleSettings(QListWidgetItem *)));
-		mL->list->setSelectionMode(QAbstractItemView::ExtendedSelection);
-		mL->list->setDragDropMode(QAbstractItemView::InternalMove);
-
-		mL->buttonsW = new QWidget;
-
-		mL->moveUp = new QToolButton;
-		mL->moveUp->setArrowType(Qt::UpArrow);
-		mL->moveUp->setToolTip(tr("Move up"));
-		connect(mL->moveUp, SIGNAL(clicked()), this, SLOT(moveModule()));
-		mL->moveUp->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred));
-
-		mL->moveDown = new QToolButton;
-		mL->moveDown->setArrowType(Qt::DownArrow);
-		mL->moveDown->setToolTip(tr("Move down"));
-		connect(mL->moveDown, SIGNAL(clicked()), this, SLOT(moveModule()));
-		mL->moveDown->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred));
-
-		mL->layout1 = new QVBoxLayout(mL->buttonsW);
-		mL->layout1->addWidget(mL->moveUp);
-		mL->layout1->addWidget(mL->moveDown);
-		mL->layout1->setSpacing(2);
-		mL->layout1->setMargin(0);
-
-		mL->layout2 = new QHBoxLayout(mL);
-		mL->layout2->addWidget(mL->list);
-		mL->layout2->addWidget(mL->buttonsW);
-		mL->layout2->setSpacing(2);
-		mL->layout2->setMargin(0);
+		QGroupBox* box = new QGroupBox(modules_title_list[m]);
+		Ui::ModulesList* ml = new Ui::ModulesList;
+		ml->setupUi(box);
+		connect(ml->list, SIGNAL(itemDoubleClicked (QListWidgetItem *)), this, SLOT(openModuleSettings(QListWidgetItem *)));
+		connect(ml->moveUp, SIGNAL(clicked()), this, SLOT(moveModule()));
+		connect(ml->moveDown, SIGNAL(clicked()), this, SLOT(moveModule()));
+		page2->modulesListLayout->addWidget(box);
+		page2_modulesList[m] = ml;
 	}
-	page2->modulesList[0]->setTitle(tr("Video output priority"));
-	page2->modulesList[1]->setTitle(tr("Audio output priority"));
-	page2->modulesList[2]->setTitle(tr("Decoders priority"));
-
-	layout_row = 0;
-	page2->w = new QWidget;
-	page2->layout2 = new QGridLayout(page2->w);
-	page2->layout2->addWidget(page2->shortSeekL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->shortSeekB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->longSeekL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->longSeekB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->bufferLocalL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->bufferLocalB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->bufferNetworkL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->bufferNetworkB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->backwardBufferNetworkL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->backwardBufferNetworkB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->playIfBufferedL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->playIfBufferedB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->maxVolL, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->maxVolB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->forceSamplerate, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->samplerateB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->forceChannels, layout_row, 0, 1, 1);
-	page2->layout2->addWidget(page2->channelsB, layout_row++, 1, 1, 1);
-	page2->layout2->addWidget(page2->replayGain, layout_row++, 0, 1, 2);
-	page2->layout2->addWidget(page2->wheelActionB, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->showBufferedTimeOnSlider, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->savePos, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->keepZoom, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->keepARatio, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->keepSubtitlesDelay, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->keepSubtitlesScale, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->keepVideoDelay, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->keepSpeed, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->syncVtoA, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->silence, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->restoreVideoEq, layout_row++, 0, 1, 3);
-	page2->layout2->addWidget(page2->ignorePlaybackError, layout_row++, 0, 1, 3);
-	page2->layout2->setMargin(0);
-	page2->layout2->setSpacing(2);
-
-	page2->scrollA = new QScrollArea;
-	page2->scrollA->setFrameShape(QFrame::NoFrame);
-	page2->scrollA->setWidget(page2->w);
-
-	page2->layout1 = new QGridLayout(page2);
-	page2->layout1->setMargin(2);
-	page2->layout1->setSpacing(3);
-	page2->layout1->addWidget(page2->scrollA, 0, 0, 1, 3);
-	for (int m = 0; m < 3; ++m)
-		page2->layout1->addWidget(page2->modulesList[m], 1, m);
 
 	/* Strona 3 */
 	page3->module = NULL;
@@ -858,11 +665,11 @@ void SettingsWidget::apply()
 			QMPSettings.set("IgnorePlaybackError", page2->ignorePlaybackError->isChecked());
 
 			QStringList videoWriters, audioWriters, decoders;
-			foreach (QListWidgetItem *wI, page2->modulesList[0]->list->findItems(QString(), Qt::MatchContains))
+			foreach (QListWidgetItem *wI, page2_modulesList[0]->list->findItems(QString(), Qt::MatchContains))
 				videoWriters += wI->text();
-			foreach (QListWidgetItem *wI, page2->modulesList[1]->list->findItems(QString(), Qt::MatchContains))
+			foreach (QListWidgetItem *wI, page2_modulesList[1]->list->findItems(QString(), Qt::MatchContains))
 				audioWriters += wI->text();
-			foreach (QListWidgetItem *wI, page2->modulesList[2]->list->findItems(QString(), Qt::MatchContains))
+			foreach (QListWidgetItem *wI, page2_modulesList[2]->list->findItems(QString(), Qt::MatchContains))
 				decoders += wI->text();
 			QMPSettings.set("videoWriters", videoWriters);
 			QMPSettings.set("audioWriters", audioWriters);
@@ -930,7 +737,7 @@ void SettingsWidget::chModule(QListWidgetItem *w)
 }
 void SettingsWidget::tabCh(int idx)
 {
-	if (idx == 1 && !page2->modulesList[0]->list->count() && !page2->modulesList[1]->list->count() && !page2->modulesList[2]->list->count())
+	if (idx == 1 && !page2_modulesList[0]->list->count() && !page2_modulesList[1]->list->count() && !page2_modulesList[2]->list->count())
 	{
 		QStringList writers[3] = {QMPlay2GUI.getModules("videoWriters", 5), QMPlay2GUI.getModules("audioWriters", 5), QMPlay2GUI.getModules("decoders", 7)};
 		QVector<QPair<Module *, Module::Info> > pluginsInstances[3];
@@ -945,26 +752,27 @@ void SettingsWidget::tabCh(int idx)
 						pluginsInstances[m][mIdx] = qMakePair(module, moduleInfo);
 				}
 		for (int m = 0; m < 3; ++m)
+		{
 			for (int i = 0; i < pluginsInstances[m].size(); i++)
 			{
 				QListWidgetItem *wI = new QListWidgetItem(writers[m][i]);
 				wI->setData(Qt::UserRole, pluginsInstances[m][i].first->name());
 				wI->setIcon(QMPlay2GUI.getIcon(pluginsInstances[m][i].second.img.isNull() ? pluginsInstances[m][i].first->image() : pluginsInstances[m][i].second.img));
-				page2->modulesList[m]->list->addItem(wI);
+				page2_modulesList[m]->list->addItem(wI);
 				if (writers[m][i] == lastM[m])
-					page2->modulesList[m]->list->setCurrentItem(wI);
+					page2_modulesList[m]->list->setCurrentItem(wI);
 			}
-		for (int m = 0; m < 3; ++m)
-			if (page2->modulesList[m]->list->currentRow() < 0)
-				page2->modulesList[m]->list->setCurrentRow(0);
+			if (page2_modulesList[m]->list->currentRow() < 0)
+				page2_modulesList[m]->list->setCurrentRow(0);
+		}
 	}
 	else if (idx == 2)
 		for (int m = 0; m < 3; ++m)
 		{
-			QListWidgetItem *currI = page2->modulesList[m]->list->currentItem();
+			QListWidgetItem *currI = page2_modulesList[m]->list->currentItem();
 			if (currI)
 				lastM[m] = currI->text();
-			page2->modulesList[m]->list->clear();
+			page2_modulesList[m]->list->clear();
 		}
 }
 void SettingsWidget::openModuleSettings(QListWidgetItem *wI)
@@ -983,12 +791,12 @@ void SettingsWidget::moveModule()
 	{
 		const bool moveDown = tB->arrowType() == Qt::DownArrow;
 		QListWidget *mL = NULL;
-		if (tB->parent() == page2->modulesList[0]->buttonsW)
-			mL = page2->modulesList[0]->list;
-		else if (tB->parent() == page2->modulesList[1]->buttonsW)
-			mL = page2->modulesList[1]->list;
-		else if (tB->parent() == page2->modulesList[2]->buttonsW)
-			mL = page2->modulesList[2]->list;
+		if (tB->parent() == page2_modulesList[0]->buttonsW)
+			mL = page2_modulesList[0]->list;
+		else if (tB->parent() == page2_modulesList[1]->buttonsW)
+			mL = page2_modulesList[1]->list;
+		else if (tB->parent() == page2_modulesList[2]->buttonsW)
+			mL = page2_modulesList[2]->list;
 		if (mL)
 		{
 			int row = mL->currentRow();
@@ -1011,11 +819,6 @@ void SettingsWidget::chooseScreenshotDir()
 	QString dir = QFileDialog::getExistingDirectory(this, tr("Choose directory"), page1->screenshotE->text());
 	if (!dir.isEmpty())
 		page1->screenshotE->setText(dir);
-}
-void SettingsWidget::page2EnableOrDisable()
-{
-	page2->samplerateB->setEnabled(page2->forceSamplerate->isChecked());
-	page2->channelsB->setEnabled(page2->forceChannels->isChecked());
 }
 void SettingsWidget::setAppearance()
 {

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -25,8 +25,6 @@ class QListWidgetItem;
 class QGridLayout;
 class QPushButton;
 class QTabWidget;
-class Page1;
-class Page2;
 class Page3;
 class Page4;
 class Page5;
@@ -34,6 +32,8 @@ class Page6;
 
 namespace Ui {
 	class GeneralSettings;
+	class PlaybackSettings;
+	class ModulesList;
 }
 
 class SettingsWidget : public QWidget
@@ -56,7 +56,8 @@ private:
 	void closeEvent(QCloseEvent *);
 
 	Ui::GeneralSettings *page1;
-	Page2 *page2;
+	Ui::PlaybackSettings *page2;
+	Ui::ModulesList *page2_modulesList[3];
 	Page3 *page3;
 	Page4 *page4;
 	Page5 *page5;
@@ -77,7 +78,6 @@ private slots:
 	void openModuleSettings(QListWidgetItem *);
 	void moveModule();
 	void chooseScreenshotDir();
-	void page2EnableOrDisable();
 	void setAppearance();
 	void clearCoversCache();
 	void resetSettings();

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -1,6 +1,6 @@
 /*
 	QMPlay2 is a video and audio player.
-	Copyright (C) 2010-2016  Błażej Szczygieł
+	Copyright (C) 2010-2016	 Błażej Szczygieł
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Lesser General Public License as published
@@ -32,6 +32,10 @@ class Page4;
 class Page5;
 class Page6;
 
+namespace Ui {
+	class GeneralSettings;
+}
+
 class SettingsWidget : public QWidget
 {
 	Q_OBJECT
@@ -51,7 +55,7 @@ private:
 	void showEvent(QShowEvent *);
 	void closeEvent(QCloseEvent *);
 
-	Page1 *page1;
+	Ui::GeneralSettings *page1;
 	Page2 *page2;
 	Page3 *page3;
 	Page4 *page4;

--- a/src/gui/ui/settings_general.ui
+++ b/src/gui/ui/settings_general.ui
@@ -1,0 +1,292 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GeneralSettings</class>
+ <widget class="QWidget" name="GeneralSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>517</width>
+    <height>625</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="langL">
+       <property name="text">
+        <string>Language: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="langBox"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="styleL">
+       <property name="text">
+        <string>Style: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="styleBox"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="encodingL">
+       <property name="text">
+        <string>Subtitles encoding: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="encodingB"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="audioLangL">
+       <property name="text">
+        <string>Default audio language: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="audioLangB"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="subsLangL">
+       <property name="text">
+        <string>Default subtitles language: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="subsLangB"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="screenshotL">
+       <property name="text">
+        <string>Screenshots path: </string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLineEdit" name="screenshotE">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="screenshotFormatB">
+         <item>
+          <property name="text">
+           <string notr="true">.ppm</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">.bmp</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">.png</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="screenshotB">
+         <property name="toolTip">
+          <string>Browse</string>
+         </property>
+         <property name="text">
+          <string>...</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="iconsFromTheme">
+       <property name="text">
+        <string>Use system icon set</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QPushButton" name="setAppearanceB">
+       <property name="text">
+        <string>Set appearance</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="showCoversB">
+     <property name="text">
+      <string>Show covers</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="blurCoversB">
+     <property name="text">
+      <string>Blurred covers as background</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="showDirCoversB">
+     <property name="text">
+      <string>Show covers from directory if there aren't in the music file</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="autoOpenVideoWindowB">
+     <property name="text">
+      <string>Automatically opening video window</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="autoUpdatesB">
+     <property name="text">
+      <string>Automatically check and download updates</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="tabsNorths">
+     <property name="text">
+      <string>Show tabs at the top of the main window</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="allowOnlyOneInstance">
+     <property name="text">
+      <string>Allow only one instance</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="displayOnlyFileName">
+     <property name="text">
+      <string>Always display only file names in playlist</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="restoreRepeatMode">
+     <property name="text">
+      <string>Remember repeat mode</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="proxyB">
+     <property name="title">
+      <string>Use proxy server</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QGroupBox" name="proxyLoginB">
+        <property name="title">
+         <string>Proxy server needs login</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QLineEdit" name="proxyUserE">
+           <property name="placeholderText">
+            <string>User name</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="proxyPasswordE">
+           <property name="echoMode">
+            <enum>QLineEdit::Password</enum>
+           </property>
+           <property name="placeholderText">
+            <string>Password</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="_2">
+        <item>
+         <widget class="QLineEdit" name="proxyHostE">
+          <property name="placeholderText">
+           <string>Proxy server address</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="proxyPortB">
+          <property name="toolTip">
+           <string>Proxy server port</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>65535</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="clearCoversCache">
+       <property name="text">
+        <string>Clear covers cache</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="resetSettingsB">
+       <property name="text">
+        <string>Reset settings</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/ui/settings_playback.ui
+++ b/src/gui/ui/settings_playback.ui
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PlaybackSettings</class>
+ <widget class="QWidget" name="PlaybackSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>586</width>
+    <height>586</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>552</width>
+        <height>801</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="shortSeekL">
+           <property name="text">
+            <string>Short seeking (left and right arrows): </string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="shortSeekB">
+           <property name="suffix">
+            <string> sec</string>
+           </property>
+           <property name="minimum">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <number>20</number>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="longSeekL">
+           <property name="text">
+            <string>Long seeking (up and down arrows): </string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="longSeekB">
+           <property name="suffix">
+            <string> sec</string>
+           </property>
+           <property name="minimum">
+            <number>30</number>
+           </property>
+           <property name="maximum">
+            <number>300</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="bufferLocalL">
+           <property name="text">
+            <string>Local buffer size (A/V packages count): </string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="bufferLocalB">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="bufferNetworkL">
+           <property name="text">
+            <string>Network buffer size (A/V packages count): </string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QSpinBox" name="bufferNetworkB">
+           <property name="minimum">
+            <number>100</number>
+           </property>
+           <property name="maximum">
+            <number>1000000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="backwardBufferNetworkL">
+           <property name="text">
+            <string>Percent of packages for backwards rewinding: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QComboBox" name="backwardBufferNetworkB">
+           <item>
+            <property name="text">
+             <string notr="true">10%</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string notr="true">25%</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string notr="true">50%</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="playIfBufferedL">
+           <property name="text">
+            <string>Start playback internet stream if it is buffered: </string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="QDoubleSpinBox" name="playIfBufferedB">
+           <property name="suffix">
+            <string> sec</string>
+           </property>
+           <property name="maximum">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.250000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="maxVolL">
+           <property name="text">
+            <string>Maximum volume</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QSpinBox" name="maxVolB">
+           <property name="suffix">
+            <string notr="true"> %</string>
+           </property>
+           <property name="minimum">
+            <number>100</number>
+           </property>
+           <property name="maximum">
+            <number>1000</number>
+           </property>
+           <property name="singleStep">
+            <number>50</number>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QCheckBox" name="forceSamplerate">
+           <property name="text">
+            <string>Force samplerate</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QSpinBox" name="samplerateB">
+           <property name="minimum">
+            <number>4000</number>
+           </property>
+           <property name="maximum">
+            <number>192000</number>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QCheckBox" name="forceChannels">
+           <property name="text">
+            <string>Force channels conversion</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QSpinBox" name="channelsB">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>8</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="replayGain">
+         <property name="title">
+          <string>Use replay gain if available</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QCheckBox" name="replayGainAlbum">
+            <property name="text">
+             <string>Album mode for replay gain</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="replayGainPreventClipping">
+            <property name="text">
+             <string>Prevent clipping</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="replayGainPreamp">
+            <property name="prefix">
+             <string>Amplify: </string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> dB</string>
+            </property>
+            <property name="minimum">
+             <double>-15.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>15.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="wheelActionB">
+         <property name="title">
+          <string>Mouse wheel action on video dock</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QRadioButton" name="wheelSeekB">
+            <property name="text">
+             <string>Mouse wheel scrolls music/movie</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="wheelVolumeB">
+            <property name="text">
+             <string>Mouse wheel changes the volume</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keepZoom">
+         <property name="text">
+          <string>Keep zoom</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="showBufferedTimeOnSlider">
+         <property name="text">
+          <string>Show buffered data indicator on slider</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keepARatio">
+         <property name="text">
+          <string>Keep aspect ratio</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="savePos">
+         <property name="text">
+          <string>Remember playback position</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keepSubtitlesDelay">
+         <property name="text">
+          <string>Keep subtitles delay</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keepSubtitlesScale">
+         <property name="text">
+          <string>Keep subtitles scale</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keepSpeed">
+         <property name="text">
+          <string>Keep speed</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="keepVideoDelay">
+         <property name="text">
+          <string>Keep video delay</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="syncVtoA">
+         <property name="text">
+          <string>Video to audio sync (frame skipping)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="silence">
+         <property name="text">
+          <string>Fade sound</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="restoreVideoEq">
+         <property name="text">
+          <string>Remember video equalizer settings</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="ignorePlaybackError">
+         <property name="text">
+          <string>Play next entry after playback error</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="modulesListLayout"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/ui/settings_playback_moduleslist.ui
+++ b/src/gui/ui/settings_playback_moduleslist.ui
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ModulesList</class>
+ <widget class="QGroupBox" name="ModulesList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QListWidget" name="list">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="buttonsW">
+     <item>
+      <widget class="QToolButton" name="moveUp">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Move up</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="arrowType">
+        <enum>Qt::UpArrow</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="moveDown">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Move down</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="arrowType">
+        <enum>Qt::DownArrow</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
About the #13 issue, I made some decisions:

1. I translated 'Strona' into 'Page' (checked using Google Translate :) )
2. Only create ui file for page 1 & page 2. Those two pages were enormous, therefore it is logical to create ui file for them. But the other pages are little / intuitive therefore I saw no need to create for them a ui file (There is a little overhead during initialization in using the generated code than yours).
3. I changed a little the concept in arranging the objects. Instead of QGridLayout I used combination of QFormLayout, QHBoxLayout and QVBoxLayout. In my opinion it is much cleaner looking now. But please says your thoughts.

Some more questions:

1. I think that moving every page (or at least page 1 & 2) into separate class and connect the signal/slot there. There will be only little more size addition to the binary, but it will make better organization.
2. The [OSDSettingsW](https://github.com/zaps166/QMPlay2/blob/master/src/gui/OSDSettingsW.hpp) is also quite long - should I also convert it into ui file?

**Reminder**: If you try to use/push to my fork, please do it into the `ui` branch. In the master branch there is future code (not ready still) for CPack, NSIS & OS X bundle.