### PR TITLE
Settings Ui OSDSettings

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -68,6 +68,7 @@ set(GUI_FORMS # *.ui files
     Ui/SettingsGeneral.ui
     Ui/SettingsPlayback.ui
     Ui/SettingsPlaybackModuleslist.ui
+    Ui/OSDSettings.ui
 )
 
 set(GUI_RESOURCES

--- a/src/gui/OSDSettingsW.cpp
+++ b/src/gui/OSDSettingsW.cpp
@@ -20,18 +20,9 @@
 
 #include <LibASS.hpp>
 #include <Main.hpp>
-
-#include <ColorButton.hpp>
 #include <Settings.hpp>
 
-#include <QDoubleSpinBox>
-#include <QFontComboBox>
 #include <QRadioButton>
-#include <QPushButton>
-#include <QGridLayout>
-#include <QGroupBox>
-#include <QSpinBox>
-#include <QLabel>
 
 void OSDSettingsW::init(const QString &prefix, int a, int b, int c, int d, int e, int f, double g, double h, const QColor &i, const QColor &j, const QColor &k)
 {
@@ -56,109 +47,15 @@ void OSDSettingsW::init(const QString &prefix, int a, int b, int c, int d, int e
 OSDSettingsW::OSDSettingsW(const QString &prefix) :
 	prefix(prefix)
 {
-	//Font GroupBox
-	fontCB = new QFontComboBox;
-	fontSizeL = new QLabel;
-	fontSizeL->setText(tr("Size") + ": ");
-	fontSizeB = new QSpinBox;
-	spacingL = new QLabel;
-	spacingL->setText(tr("Spacing") + ": ");
-	spacingB = new QSpinBox;
-	spacingB->setMinimum(-20);
-	spacingB->setMaximum(20);
+	setupUi(this);
 
-	fontGB = new QGroupBox;
-	fontGB->setTitle(tr("Font"));
-
-	fontL = new QGridLayout(fontGB);
-	fontL->addWidget(fontCB, 0, 0, 1, 2);
-	fontL->addWidget(fontSizeL, 1, 0, 1, 1);
-	fontL->addWidget(fontSizeB, 1, 1, 1, 1);
-	fontL->addWidget(spacingL, 2, 0, 1, 1);
-	fontL->addWidget(spacingB, 2, 1, 1, 1 );
-
-	//Margins GroupBox
-	leftMarginL = new QLabel;
-	leftMarginL->setText(tr("Left") + ": ");
-	leftMarginB = new QSpinBox;
-	rightMarginL = new QLabel;
-	rightMarginL->setText(tr("Right") + ": ");
-	rightMarginB = new QSpinBox;
-	vMarginL = new QLabel;
-	vMarginL->setText(tr("Vertical") + ": ");
-	vMarginB = new QSpinBox;
-
-	marginsGB = new QGroupBox;
-	marginsGB->setTitle(tr("Margins"));
-
-	marginsL = new QGridLayout(marginsGB);
-	marginsL->addWidget(leftMarginL, 0, 0);
-	marginsL->addWidget(leftMarginB, 0, 1);
-	marginsL->addWidget(rightMarginL, 1, 0);
-	marginsL->addWidget(rightMarginB, 1, 1);
-	marginsL->addWidget(vMarginL, 2, 0);
-	marginsL->addWidget(vMarginB, 2, 1);
-
-	//Alignment GroupBox
-	alignGB = new QGroupBox;
-	alignGB->setTitle(tr("Subtitles alignment"));
-
-	alignL = new QGridLayout(alignGB);
+	// Alignment GroupBox
+	QGridLayout* alignL = new QGridLayout(alignGB);
 	for (int align = 0; align < 9; align++)
 	{
 		alignB[align] = new QRadioButton;
 		alignL->addWidget(alignB[align], align/3, align%3);
 	}
-
-	//Frame GroupBox
-	outlineL = new QLabel;
-	outlineL->setText(tr("Outline") + ": ");
-	outlineB = new QDoubleSpinBox;
-	outlineB->setMaximum(4.);
-	shadowL = new QLabel;
-	shadowL->setText(tr("Shadow") + ": ");
-	shadowB = new QDoubleSpinBox;
-	shadowB->setMaximum(4.);
-
-	frameGB = new QGroupBox;
-	frameGB->setTitle(tr("Border"));
-
-	frameL = new QGridLayout(frameGB);
-	frameL->addWidget(outlineL, 0, 0);
-	frameL->addWidget(outlineB, 0, 1);
-	frameL->addWidget(shadowL, 1, 0);
-	frameL->addWidget(shadowB, 1, 1);
-
-	//Colors GroupBox
-	textColorL = new QLabel;
-	textColorL->setText(tr("Text") + ": ");
-	textColorB = new ColorButton;
-	outlineColorL = new QLabel;
-	outlineColorL->setText(tr("Border") + ": ");
-	outlineColorB = new ColorButton;
-	shadowColorL = new QLabel;
-	shadowColorL->setText(tr("Shadow") + ": ");
-	shadowColorB = new ColorButton;
-
-	colorsGB = new QGroupBox;
-	colorsGB->setTitle(tr("Colors"));
-
-	colorsL = new QGridLayout(colorsGB);
-	colorsL->addWidget(textColorL, 0, 0);
-	colorsL->addWidget(textColorB, 0, 1);
-	colorsL->addWidget(outlineColorL, 1, 0);
-	colorsL->addWidget(outlineColorB, 1, 1);
-	colorsL->addWidget(shadowColorL, 2, 0);
-	colorsL->addWidget(shadowColorB, 2, 1);
-
-	//Widget layout
-	layout = new QGridLayout(this);
-	layout->setMargin(1);
-	layout->addWidget(fontGB, 0, 0, 1, 2);
-	layout->addWidget(marginsGB, 0, 2, 1, 3);
-	layout->addWidget(alignGB, 1, 0, 1, 1);
-	layout->addWidget(frameGB, 1, 1, 1, 2);
-	layout->addWidget(colorsGB, 1, 3, 1, 2);
 
 	readSettings();
 

--- a/src/gui/OSDSettingsW.hpp
+++ b/src/gui/OSDSettingsW.hpp
@@ -20,39 +20,23 @@
 #define OSDSETTINGSW_HPP
 
 #include <QWidget>
+#include "ui_OSDSettings.h"
 
-class QDoubleSpinBox;
-class QFontComboBox;
 class QRadioButton;
-class ColorButton;
-class QGridLayout;
-class QGroupBox;
-class QSpinBox;
-class QLabel;
 
-class OSDSettingsW : public QWidget
+class OSDSettingsW : public QWidget, public Ui::OSDSettings
 {
-	Q_OBJECT
 public:
 	static void init(const QString &, int, int, int, int, int, int, double, double, const QColor &, const QColor &, const QColor &);
 
 	OSDSettingsW(const QString &);
 
 	void writeSettings();
-
-	QGridLayout *layout, *fontL, *marginsL, *alignL, *frameL, *colorsL;
 private:
 	void readSettings();
 
 	QString prefix;
 
-	QGroupBox *fontGB, *marginsGB, *alignGB, *frameGB, *colorsGB;
-
-	QLabel *fontSizeL, *spacingL, *leftMarginL, *rightMarginL, *vMarginL, *outlineL, *shadowL, *textColorL, *outlineColorL, *shadowColorL;
-	QFontComboBox *fontCB;
-	QSpinBox *fontSizeB, *spacingB, *leftMarginB, *rightMarginB, *vMarginB;
-	QDoubleSpinBox *outlineB, *shadowB;
-	ColorButton *textColorB, *outlineColorB, *shadowColorB;
 	QRadioButton *alignB[9];
 
 };

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -471,15 +471,12 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 	page4->layout2->addWidget(page4->fontsB, 0, 1, 1, 1);
 	page4->layout2->addWidget(page4->overridePlayResB, 1, 1, 1, 1);
 
-	page4->layout->addWidget(page4->toASSGB, 2, 0, 1, 5);
-	AddVHSpacer(*page4->layout);
+	page4->_layout->addWidget(page4->toASSGB);
 
 	/* Page 5 */
 	page5->enabledB = new QCheckBox(tr("OSD enabled"));
 	page5->enabledB->setChecked(QMPSettings.getBool("OSD/Enabled"));
-
-	page5->layout->addWidget(page5->enabledB, 2, 0, 1, 5);
-	AddVHSpacer(*page5->layout);
+	page5->_layout->addWidget(page5->enabledB);
 
 	/* Page 6 */
 	page6->deintSettingsW = new DeintSettingsW;

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -245,16 +245,16 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName) :
 	tabW->addTab(page5, tr("OSD"));
 	tabW->addTab(page6, tr("Video filters"));
 
-	applyB = new QPushButton;
+	QPushButton *applyB = new QPushButton;
 	applyB->setText(tr("Apply"));
 	connect(applyB, SIGNAL(clicked()), this, SLOT(apply()));
 
-	closeB = new QPushButton;
+	QPushButton *closeB = new QPushButton;
 	closeB->setText(tr("Close"));
 	closeB->setShortcut(QKeySequence("Escape"));
 	connect(closeB, SIGNAL(clicked()), this, SLOT(close()));
 
-	layout = new QGridLayout(this);
+	QGridLayout *layout = new QGridLayout(this);
 	layout->addWidget(tabW, 0, 0, 1, 3);
 	layout->addWidget(applyB, 1, 1, 1, 1);
 	layout->addWidget(closeB, 1, 2, 1, 1);

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -63,9 +63,7 @@ private:
 	Page5 *page5;
 	Page6 *page6;
 
-	QGridLayout *layout;
 	QTabWidget *tabW;
-	QPushButton *applyB, *closeB;
 	QString lastM[3];
 
 	bool wasShow;

--- a/src/gui/Ui/OSDSettings.ui
+++ b/src/gui/Ui/OSDSettings.ui
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OSDSettings</class>
+ <widget class="QWidget" name="OSDSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>557</width>
+    <height>401</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="_layout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QGroupBox" name="fontGB">
+         <property name="title">
+          <string>Font</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0" colspan="2">
+           <widget class="QFontComboBox" name="fontCB"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="fontSizeL">
+            <property name="text">
+             <string>Size: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="fontSizeB"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="spacingL">
+            <property name="text">
+             <string>Spacing: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="spacingB">
+            <property name="minimum">
+             <number>-20</number>
+            </property>
+            <property name="maximum">
+             <number>20</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="marginsGB">
+         <property name="title">
+          <string>Margins</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="leftMarginL">
+            <property name="text">
+             <string>Left: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="leftMarginB"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="rightMarginL">
+            <property name="text">
+             <string>Right: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="rightMarginB"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="vMarginL">
+            <property name="text">
+             <string>Vertical: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="vMarginB"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="alignGB">
+         <property name="title">
+          <string>Subtitles alignment</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="frameGB">
+         <property name="title">
+          <string>Border</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="outlineL">
+            <property name="text">
+             <string>Outline: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="outlineB">
+            <property name="maximum">
+             <double>4.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="shadowL">
+            <property name="text">
+             <string>Shadow: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="shadowB">
+            <property name="maximum">
+             <double>4.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="colorsGB">
+         <property name="title">
+          <string>Colors</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="textColorL">
+            <property name="text">
+             <string>Text: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="ColorButton" name="textColorB">
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="outlineColorL">
+            <property name="text">
+             <string>Border: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="ColorButton" name="outlineColorB">
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="shadowColorL">
+            <property name="text">
+             <string>Shadow: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="ColorButton" name="shadowColorB">
+            <property name="text">
+             <string>PushButton</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>89</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>121</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>ColorButton.hpp</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/gui/Ui/SettingsPlaybackModuleslist.ui
+++ b/src/gui/Ui/SettingsPlaybackModuleslist.ui
@@ -28,6 +28,12 @@
      <property name="selectionMode">
       <enum>QAbstractItemView::ExtendedSelection</enum>
      </property>
+     <property name="iconSize">
+      <size>
+       <width>32</width>
+       <height>32</height>
+      </size>
+     </property>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
The next PR about issue #13 :)

This PR includes `OSDSettings` ui file (it was quite big and now it is a little better). As Page 4 & 5 use this widget, I created a little "hack" that enables those pages to add widgets after the widget and still look good (direct access to the VBox).

After some inspection, I think that Page 3 & 5 & 6 should not be converted to ui file (the UI code is too simple). Page 4 is around creating a simple GroupBox and appending it to OSDSettings, therefore I don't think it is worth moving to ui file.

I do see a difference in margin, spacing between yours QGridLayout and mine approach. In my opinion (which might be wrong for most people) my approach is better because this extra spacing makes reading the settings a lot easier, and the auto resize after window resize is a lot cleaner.

The [last commit](https://github.com/zaps166/QMPlay2/commit/2dca495fc0b4ac4262d031b582839c7d68a00a7e) is a small change to remove pointers that are used only during initialization. I think it would be a good idea to do it, saving a little space. It would be much better to also remove more unused pointers, but there would be a need to change the names, like changing `page6->layout` to `page6_layout`. But for this change I prefer to hear your decision.

The last point: conflict between the branches. There is currently a conflict between master and settings-ui. I checked how to fix this conflict (by doing `git checkout settings-ui` -> `git rebase master`) is to remove all the master changes and remain the settings-ui changes. Also I think that we should do a periodical rebase to master. This rebase will need a `git push -f` but this branch is an internal dev branch therefore it won't be a problem if history changes for this branch.