### PR TITLE
Various Small Fixes

### DIFF
--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -852,7 +852,7 @@ void SettingsWidget::applyProxy()
 		if (QMPSettings.getBool("Proxy/Login"))
 		{
 			proxy.setUser(QMPSettings.getString("Proxy/User"));
-			proxy.setPassword(QByteArray::fromBase64(QMPSettings.getString("Proxy/Password").toLatin1()));
+			proxy.setPassword(QByteArray::fromBase64(QMPSettings.getByteArray("Proxy/Password")));
 		}
 
 		/* Proxy env for FFmpeg */

--- a/src/gui/VideoAdjustment.cpp
+++ b/src/gui/VideoAdjustment.cpp
@@ -67,8 +67,7 @@ VideoAdjustment::VideoAdjustment() :
 		slider->setTickPosition(QSlider::TicksBelow);
 		slider->setMinimumWidth(50);
 		slider->setTickInterval(25);
-		slider->setMinimum(-100);
-		slider->setMaximum(100);
+		slider->setRange(-100, 100);
 		slider->setWheelStep(1);
 		slider->setValue(0);
 

--- a/src/qmplay2/QMPlay2Core.cpp
+++ b/src/qmplay2/QMPlay2Core.cpp
@@ -101,7 +101,7 @@ QString QMPlay2CoreClass::getLibDir()
 bool QMPlay2CoreClass::canSuspend()
 {
 #if defined Q_OS_LINUX
-	return !system("systemctl --help 2> /dev/null | grep suspend > /dev/null 2>&1");
+	return !system("systemctl --help 2> /dev/null | grep -q suspend");
 #elif defined Q_OS_WIN
 	return true;
 #else


### PR DESCRIPTION
This is a collection of small 3 fixes. Some more info about them:

1. patch c53d6dfcbc4689cc3001908d843f99b1cb31d228 - use like used in [here](https://github.com/zaps166/QMPlay2/blob/master/src/gui/SettingsWidget.cpp#L441). I think this will work better.
2. patch e5e2b29ab328473c8661ee220dfd43a8c0dd3faa - POSIX grep command has the `-q` switch which won't output. I think it is better than the redirection.
3. patch a35d0be2755d7d2ea20faeb93ce993b854e0b2b8 - use setRange instead of setMinimum with setMaximum (less lines, more readable, more optimized call).

Btw, if I will find some other small fixes like in this PR, do you prefer to send them as small patch file which you can commit or as a new PR?