### PR TITLE
Move to QFormLayout

### DIFF
--- a/src/gui/Appearance.cpp
+++ b/src/gui/Appearance.cpp
@@ -31,6 +31,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QGridLayout>
+#include <QFormLayout>
 #include <QGroupBox>
 #include <QSettings>
 #include <QComboBox>
@@ -248,62 +249,24 @@ Appearance::Appearance(QWidget *p) :
 	useColorsB = new QGroupBox(tr("Use custom colors"));
 	useColorsB->setCheckable(true);
 
-	QLabel *buttonL = new QLabel(tr("Buttons color") + ":");
-	QLabel *windowL = new QLabel(tr("Window color") + ":");
-	QLabel *shadowL = new QLabel(tr("Border color") + ":");
-	QLabel *highlightL = new QLabel(tr("Highlight color") + ":");
-	QLabel *baseL = new QLabel(tr("Base color") + ":");
-	QLabel *textL = new QLabel(tr("Text color") + ":");
-	QLabel *highlightedTextL = new QLabel(tr("Highlighted text color") + ":");
-	QLabel *sliderButtonL = new QLabel(tr("Slider button color") + ":");
-
-	buttonC = new ColorButton(false);
-	windowC = new ColorButton(false);
-	shadowC = new ColorButton(false);
-	highlightC = new ColorButton(false);
-	baseC = new ColorButton(false);
-	textC = new ColorButton(false);
-	highlightedTextC = new ColorButton(false);
-	sliderButtonC = new ColorButton(false);
-
-	int layout_row = 0;
-	layout = new QGridLayout(useColorsB);
-	layout->addWidget(buttonL, layout_row, 0, 1, 1);
-	layout->addWidget(buttonC, layout_row++, 1, 1, 1);
-	layout->addWidget(windowL, layout_row, 0, 1, 1);
-	layout->addWidget(windowC, layout_row++, 1, 1, 1);
-	layout->addWidget(shadowL, layout_row, 0, 1, 1);
-	layout->addWidget(shadowC, layout_row++, 1, 1, 1);
-	layout->addWidget(highlightL, layout_row, 0, 1, 1);
-	layout->addWidget(highlightC, layout_row++, 1, 1, 1);
-	layout->addWidget(baseL, layout_row, 0, 1, 1);
-	layout->addWidget(baseC, layout_row++, 1, 1, 1);
-	layout->addWidget(textL, layout_row, 0, 1, 1);
-	layout->addWidget(textC, layout_row++, 1, 1, 1);
-	layout->addWidget(highlightedTextL, layout_row, 0, 1, 1);
-	layout->addWidget(highlightedTextC, layout_row++, 1, 1, 1);
-	layout->addWidget(sliderButtonL, layout_row, 0, 1, 1);
-	layout->addWidget(sliderButtonC, layout_row++, 1, 1, 1);
-	layout->setMargin(3);
+	QFormLayout *formLayout = new QFormLayout(useColorsB);
+	formLayout->addRow(tr("Buttons color") + ":", buttonC = new ColorButton(false));
+	formLayout->addRow(tr("Window color") + ":", windowC = new ColorButton(false));
+	formLayout->addRow(tr("Border color") + ":", shadowC = new ColorButton(false));
+	formLayout->addRow(tr("Highlight color") + ":", highlightC = new ColorButton(false));
+	formLayout->addRow(tr("Base color") + ":", baseC = new ColorButton(false));
+	formLayout->addRow(tr("Text color") + ":", textC = new ColorButton(false));
+	formLayout->addRow(tr("Highlighted text color") + ":", highlightedTextC = new ColorButton(false));
+	formLayout->addRow(tr("Slider button color") + ":", sliderButtonC = new ColorButton(false));
+	formLayout->setMargin(3);
 
 
 	gradientB = new QGroupBox(tr("Gradient in the video window"));
 
-	QLabel *grad1L = new QLabel(tr("The color on the top and bottom") + ":");
-	QLabel *grad2L = new QLabel(tr("Color in the middle") + ":");
-	QLabel *qmpTxtL = new QLabel(tr("Text color") + ":");
-
-	grad1C = new ColorButton(false);
-	grad2C = new ColorButton(false);
-	qmpTxtC = new ColorButton(false);
-
-	layout = new QGridLayout(gradientB);
-	layout->addWidget(grad1L, 0, 0, 1, 1);
-	layout->addWidget(grad1C, 0, 1, 1, 1);
-	layout->addWidget(grad2L, 1, 0, 1, 1);
-	layout->addWidget(grad2C, 1, 1, 1, 1);
-	layout->addWidget(qmpTxtL, 2, 0, 1, 1);
-	layout->addWidget(qmpTxtC, 2, 1, 1, 1);
+	formLayout = new QFormLayout(gradientB);
+	formLayout->addRow(tr("The color on the top and bottom") + ":", grad1C = new ColorButton(false));
+	formLayout->addRow(tr("Color in the middle") + ":", grad2C = new ColorButton(false));
+	formLayout->addRow(tr("Text color") + ":", qmpTxtC = new ColorButton(false));
 
 
 	useWallpaperB = new QGroupBox(tr("Wallpaper in the main window"));

--- a/src/gui/DeintSettingsW.cpp
+++ b/src/gui/DeintSettingsW.cpp
@@ -22,7 +22,7 @@
 #include <Module.hpp>
 #include <Main.hpp>
 
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLabel>
@@ -58,12 +58,7 @@ DeintSettingsW::DeintSettingsW()
 	autoParityB = new QCheckBox(tr("Automatically detect parity"));
 	autoParityB->setChecked(QMPSettings.getBool("Deinterlace/AutoParity"));
 
-	QLabel *methodL = new QLabel(tr("Deinterlacing method (software decoding)") + ": ");
-
 	softwareMethodsCB = new QComboBox;
-	softwareMethodsCB->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
-
-	QLabel *parityL = new QLabel(tr("Parity (if not detected automatically)") + ": ");
 
 	parityCB = new QComboBox;
 	parityCB->addItems(QStringList() << "Bottom field first" << "Top field first");
@@ -72,15 +67,12 @@ DeintSettingsW::DeintSettingsW()
 	connect(softwareMethodsCB, SIGNAL(currentIndexChanged(int)), this, SLOT(setSoftwareMethodsToolTip(int)));
 	softwareMethods(doublerB->isChecked());
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(autoDeintB, 0, 0, 1, 3);
-	layout->addWidget(doublerB, 1, 0, 1, 3);
-	layout->addWidget(autoParityB, 2, 0, 1, 3);
-	layout->addWidget(methodL, 3, 0, 1, 1);
-	layout->addWidget(softwareMethodsCB, 3, 1, 1, 2);
-	layout->addWidget(parityL, 4, 0, 1, 1);
-	layout->addWidget(parityCB, 4, 1, 1, 2);
-	layout->addItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding), layout->rowCount(), 0);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(autoDeintB);
+	layout->addRow(doublerB);
+	layout->addRow(autoParityB);
+	layout->addRow(tr("Deinterlacing method (software decoding)") + ": ", softwareMethodsCB);
+	layout->addRow(tr("Parity (if not detected automatically)") + ": ", parityCB);
 }
 
 void DeintSettingsW::writeSettings()

--- a/src/gui/TagEditor.cpp
+++ b/src/gui/TagEditor.cpp
@@ -112,7 +112,8 @@ static inline Ogg::XiphComment *getXiphComment(File &file)
 #include <QImageReader>
 #include <QFileDialog>
 #include <QPushButton>
-#include <QGridLayout>
+#include <QFormLayout>
+#include <QBoxLayout>
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QPainter>
@@ -174,27 +175,10 @@ TagEditor::TagEditor() :
 	setTitle(tr("Add tags"));
 	setCheckable(true);
 
-	QLabel *titleL = new QLabel(tr("Title") + ": ");
-	titleE = new QLineEdit;
-
-	QLabel *artistL = new QLabel(tr("Artist") + ": ");
-	artistE = new QLineEdit;
-
-	QLabel *albumL = new QLabel(tr("Album") + ": ");
-	albumE = new QLineEdit;
-
-	QLabel *commentL = new QLabel(tr("Comment") + ": ");
-	commentE = new QLineEdit;
-
-	QLabel *genreL = new QLabel(tr("Genre") + ": ");
-	genreE = new QLineEdit;
-
-	QLabel *yearL = new QLabel(tr("Year") + ": ");
 	yearB = new QSpinBox;
 	yearB->setRange(0, 32767);
 	yearB->setSpecialValueText(tr("None"));
 
-	QLabel *trackL = new QLabel(tr("Track") + ": ");
 	trackB = new QSpinBox;
 	trackB->setRange(0, 32767);
 	trackB->setSpecialValueText(tr("None"));
@@ -202,37 +186,31 @@ TagEditor::TagEditor() :
 	pictureB = new QGroupBox(tr("Cover"));
 	pictureB->setCheckable(true);
 	pictureW = new PictureW(*picture);
-	loadImgB = new QPushButton;
-	loadImgB->setText(tr("Load cover picture"));
+	loadImgB = new QPushButton(tr("Load cover picture"));
 	loadImgB->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-	saveImgB = new QPushButton;
-	saveImgB->setText(tr("Save cover picture"));
+	saveImgB = new QPushButton(tr("Save cover picture"));
 	saveImgB->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
 
 	connect(loadImgB, SIGNAL(clicked()), this, SLOT(loadImage()));
 	connect(saveImgB, SIGNAL(clicked()), this, SLOT(saveImage()));
 
-	QGridLayout *pictureLayout = new QGridLayout(pictureB);
-	pictureLayout->addWidget(pictureW, 0, 0);
-	pictureLayout->addWidget(loadImgB, 1, 0);
-	pictureLayout->addWidget(saveImgB, 2, 0);
+	QVBoxLayout *pictureLayout = new QVBoxLayout(pictureB);
+	pictureLayout->addWidget(pictureW);
+	pictureLayout->addWidget(loadImgB);
+	pictureLayout->addWidget(saveImgB);
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(titleL, 0, 0, 1, 1);
-	layout->addWidget(titleE, 0, 1, 1, 1);
-	layout->addWidget(artistL, 1, 0, 1, 1);
-	layout->addWidget(artistE, 1, 1, 1, 1);
-	layout->addWidget(albumL, 2, 0, 1, 1);
-	layout->addWidget(albumE, 2, 1, 1, 1);
-	layout->addWidget(commentL, 3, 0, 1, 1);
-	layout->addWidget(commentE, 3, 1, 1, 1);
-	layout->addWidget(genreL, 4, 0, 1, 1);
-	layout->addWidget(genreE, 4, 1, 1, 1);
-	layout->addWidget(yearL, 5, 0, 1, 1);
-	layout->addWidget(yearB, 5, 1, 1, 1);
-	layout->addWidget(trackL, 6, 0, 1, 1);
-	layout->addWidget(trackB, 6, 1, 1, 1);
-	layout->addWidget(pictureB, 0, 2, 8, 1);
+	QFormLayout *tagsLayout = new QFormLayout;
+	tagsLayout->addRow(tr("Title") + ": ", titleE = new QLineEdit);
+	tagsLayout->addRow(tr("Artist") + ": ", artistE = new QLineEdit);
+	tagsLayout->addRow(tr("Album") + ": ", albumE = new QLineEdit);
+	tagsLayout->addRow(tr("Comment") + ": ", commentE = new QLineEdit);
+	tagsLayout->addRow(tr("Genre") + ": ", genreE = new QLineEdit);
+	tagsLayout->addRow(tr("Year") + ": ", yearB);
+	tagsLayout->addRow(tr("Track") + ": ", trackB);
+
+	QHBoxLayout *layout = new QHBoxLayout(this);
+	layout->addLayout(tagsLayout);
+	layout->addWidget(pictureB);
 }
 TagEditor::~TagEditor()
 {

--- a/src/modules/ALSA/ALSA.cpp
+++ b/src/modules/ALSA/ALSA.cpp
@@ -54,7 +54,7 @@ QMPLAY2_EXPORT_PLUGIN(ALSA)
 /**/
 
 #include <QDoubleSpinBox>
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QComboBox>
 #include <QCheckBox>
 #include <QLabel>
@@ -71,15 +71,11 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	autoMultichnB = new QCheckBox(tr("Automatic looking for multichannel device"));
 	autoMultichnB->setChecked(sets().getBool("AutoFindMultichnDev"));
 
-	QLabel *delayL = new QLabel(tr("Delay") + ": ");
-
 	delayB = new QDoubleSpinBox;
 	delayB->setRange(0.01, 1.0);
 	delayB->setSingleStep(0.01);
 	delayB->setSuffix(" " + tr("sec"));
 	delayB->setValue(sets().getDouble("Delay"));
-
-	QLabel *devicesL = new QLabel(tr("Playback device") + ": ");
 
 	devicesB = new QComboBox;
 	for (int i = 0; i < devicesList.first.count(); ++i)
@@ -94,13 +90,11 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 			devicesB->setCurrentIndex(i);
 	}
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(enabledB, 0, 0, 1, 2);
-	layout->addWidget(devicesL, 1, 0, 1, 1);
-	layout->addWidget(devicesB, 1, 1, 1, 1);
-	layout->addWidget(delayL, 2, 0, 1, 1);
-	layout->addWidget(delayB, 2, 1, 1, 1);
-	layout->addWidget(autoMultichnB, 3, 0, 1, 2);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(enabledB);
+	layout->addRow(tr("Delay") + ": ", delayB);
+	layout->addRow(tr("Playback device") + ": ", devicesB);
+	layout->addRow(autoMultichnB);
 }
 
 void ModuleSettingsWidget::saveSettings()

--- a/src/modules/Extensions/Extensions.cpp
+++ b/src/modules/Extensions/Extensions.cpp
@@ -169,8 +169,6 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	connect(youtubedlBrowseB, SIGNAL(clicked()), this, SLOT(browseYoutubedl()));
 
 
-	QWidget *itagW = new QWidget;
-
 	QLabel *itagL = new QLabel(tr("Priority of default video/audio quality") + ": ");
 
 	itagLW = new QListWidget;
@@ -210,7 +208,7 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 
 	enableItagLists(multiStreamB->isChecked());
 
-	QGridLayout *itagLayout = new QGridLayout(itagW);
+	QGridLayout *itagLayout = new QGridLayout;
 	itagLayout->addWidget(itagVideoL, 0, 0, 1, 1);
 	itagLayout->addWidget(itagVideoLW, 1, 0, 1, 1);
 	itagLayout->addWidget(itagAudioL, 0, 1, 1, 1);
@@ -227,7 +225,7 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	layout->addWidget(youtubedlL, 3, 0, 1, 1);
 	layout->addWidget(youtubedlE, 3, 1, 1, 1);
 	layout->addWidget(youtubedlBrowseB, 3, 2, 1, 1);
-	layout->addWidget(itagW, 4, 0, 1, 3);
+	layout->addLayout(itagLayout, 4, 0, 1, 3);
 	layout->setMargin(2);
 
 	/**/

--- a/src/modules/FFmpeg/FFmpeg.cpp
+++ b/src/modules/FFmpeg/FFmpeg.cpp
@@ -162,6 +162,7 @@ QMPLAY2_EXPORT_PLUGIN(FFmpeg)
 #include <Slider.hpp>
 
 #include <QGridLayout>
+#include <QFormLayout>
 #include <QGroupBox>
 #include <QCheckBox>
 #include <QComboBox>
@@ -183,15 +184,11 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	decoderVDPAUB->setCheckable(true);
 	decoderVDPAUB->setChecked(sets().getBool("DecoderVDPAUEnabled"));
 
-	QLabel *vdpauDeintMethodL = new QLabel(tr("Improving deinterlacing quality") + ": ");
-
 	vdpauDeintMethodB = new QComboBox;
 	vdpauDeintMethodB->addItems(QStringList() << tr("None") << "Temporal" << "Temporal-spatial");
 	vdpauDeintMethodB->setCurrentIndex(sets().getInt("VDPAUDeintMethod"));
 	if (vdpauDeintMethodB->currentIndex() < 0)
 		vdpauDeintMethodB->setCurrentIndex(1);
-
-	QLabel *vdpauHQScalingL = new QLabel(tr("Image scaling level") + ": ");
 
 	vdpauHQScalingB = new QComboBox;
 	for (int i = 0; i <= 9; ++i)
@@ -211,13 +208,10 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 
 	checkEnables();
 
-	QGridLayout *vdpauLayout = new QGridLayout(decoderVDPAUB);
-	vdpauLayout->addWidget(vdpauDeintMethodL, 0, 0, 1, 1);
-	vdpauLayout->addWidget(vdpauDeintMethodB, 0, 1, 1, 1);
-	vdpauLayout->addWidget(vdpauHQScalingL, 1, 0, 1, 1);
-	vdpauLayout->addWidget(vdpauHQScalingB, 1, 1, 1, 1);
-	vdpauLayout->addWidget(noisereductionVDPAUB, 2, 0, 1, 1);
-	vdpauLayout->addWidget(noisereductionLvlVDPAUS, 2, 1, 1, 1);
+	QFormLayout *vdpauLayout = new QFormLayout(decoderVDPAUB);
+	vdpauLayout->addRow(tr("Improving deinterlacing quality") + ": ", vdpauDeintMethodB);
+	vdpauLayout->addRow(tr("Image scaling level") + ": ", vdpauHQScalingB);
+	vdpauLayout->addRow(noisereductionVDPAUB, noisereductionLvlVDPAUS);
 
 
 	decoderVDPAU_NWB = new QCheckBox(tr("Decoder") + " VDPAU (no output) - " + tr("hardware decoding"));
@@ -233,26 +227,21 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	allowVDPAUinVAAPIB = new QCheckBox(tr("Allow VDPAU"));
 	allowVDPAUinVAAPIB->setChecked(sets().getBool("AllowVDPAUinVAAPI"));
 
-	QLabel *vaapiDeintMethodL = new QLabel(tr("Improving deinterlacing quality") + ": ");
-
 	vaapiDeintMethodB = new QComboBox;
 	vaapiDeintMethodB->addItems(QStringList() << tr("None") << "Motion adaptive" << "Motion compensated");
 	vaapiDeintMethodB->setCurrentIndex(sets().getInt("VAAPIDeintMethod"));
 	if (vaapiDeintMethodB->currentIndex() < 0)
 		vaapiDeintMethodB->setCurrentIndex(1);
 
-	QGridLayout *vaapiLayout = new QGridLayout(decoderVAAPIEB);
-	vaapiLayout->addWidget(allowVDPAUinVAAPIB, 0, 0, 1, 2);
-	vaapiLayout->addWidget(vaapiDeintMethodL, 1, 0, 1, 1);
-	vaapiLayout->addWidget(vaapiDeintMethodB, 1, 1, 1, 1);
+	QFormLayout *vaapiLayout = new QFormLayout(decoderVAAPIEB);
+	vaapiLayout->addRow(allowVDPAUinVAAPIB);
+	vaapiLayout->addRow(tr("Improving deinterlacing quality") + ": ", vaapiDeintMethodB);
 
 	#ifndef HAVE_VPP
-		vaapiDeintMethodL->setEnabled(false);
 		vaapiDeintMethodB->setEnabled(false);
 	#endif
 #endif
 
-	/* Pospiesz się */
 	hurryUpB = new QGroupBox(tr("Hurry up"));
 	hurryUpB->setCheckable(true);
 	hurryUpB->setChecked(sets().getBool("HurryUP"));
@@ -268,14 +257,10 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	hurryUpLayout->addWidget(forceSkipFramesB);
 	/**/
 
-	QLabel *threadsL = new QLabel(tr("Number of threads used to decode video") + ": ");
-
 	threadsB = new QSpinBox;
 	threadsB->setRange(0, 16);
 	threadsB->setSpecialValueText(tr("Autodetect"));
 	threadsB->setValue(sets().getInt("Threads"));
-
-	QLabel *lowresL = new QLabel(tr("Low resolution decoding (only some codecs)") + ": ");
 
 	lowresB = new QComboBox;
 	lowresB->addItems(QStringList() << tr("Normal size") << tr("4x smaller") << tr("16x smaller"));
@@ -286,8 +271,6 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 		sets().set("LowresValue", 0);
 	}
 
-	QLabel *thrTypeL = new QLabel(tr("Method of multithreaded decoding") + ": ");
-
 	thrTypeB = new QComboBox;
 	thrTypeB->addItems(QStringList() << tr("Frames") << tr("Slices"));
 	thrTypeB->setCurrentIndex(sets().getInt("ThreadTypeSlice"));
@@ -297,14 +280,11 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 		sets().set("ThreadTypeSlice", 0);
 	}
 
-	QGridLayout *decoderLayout = new QGridLayout(decoderB);
-	decoderLayout->addWidget(threadsL, 0, 0, 1, 1);
-	decoderLayout->addWidget(threadsB, 0, 1, 1, 1);
-	decoderLayout->addWidget(lowresL, 1, 0, 1, 1);
-	decoderLayout->addWidget(lowresB, 1, 1, 1, 1);
-	decoderLayout->addWidget(thrTypeL, 2, 0, 1, 1);
-	decoderLayout->addWidget(thrTypeB, 2, 1, 1, 1);
-	decoderLayout->addWidget(hurryUpB, 3, 0, 1, 2);
+	QFormLayout *decoderLayout = new QFormLayout(decoderB);
+	decoderLayout->addRow(tr("Number of threads used to decode video") + ": ", threadsB);
+	decoderLayout->addRow(tr("Low resolution decoding (only some codecs)") + ": ", lowresB);
+	decoderLayout->addRow(tr("Method of multithreaded decoding") + ": ", thrTypeB);
+	decoderLayout->addRow(hurryUpB);
 
 	connect(skipFramesB, SIGNAL(clicked(bool)), forceSkipFramesB, SLOT(setEnabled(bool)));
 	if (hurryUpB->isChecked() || !skipFramesB->isChecked())

--- a/src/modules/FFmpeg/FFmpeg.cpp
+++ b/src/modules/FFmpeg/FFmpeg.cpp
@@ -239,6 +239,7 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 
 	#ifndef HAVE_VPP
 		vaapiDeintMethodB->setEnabled(false);
+		vaapiLayout->labelForField(vaapiDeintMethodB)->setEnabled(false);
 	#endif
 #endif
 

--- a/src/modules/FFmpeg/FFmpeg.cpp
+++ b/src/modules/FFmpeg/FFmpeg.cpp
@@ -242,6 +242,7 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	#endif
 #endif
 
+	/* Hurry up */
 	hurryUpB = new QGroupBox(tr("Hurry up"));
 	hurryUpB->setCheckable(true);
 	hurryUpB->setChecked(sets().getBool("HurryUP"));

--- a/src/modules/Modplug/Modplug.cpp
+++ b/src/modules/Modplug/Modplug.cpp
@@ -54,7 +54,7 @@ QMPLAY2_EXPORT_PLUGIN(Modplug)
 
 /**/
 
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLabel>
@@ -65,8 +65,6 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	enabledB = new QCheckBox("Modplug " + tr("enabled"));
 	enabledB->setChecked(sets().getBool("ModplugEnabled"));
 
-	QLabel *resamplingL = new QLabel(tr("Resampling method") + ": ");
-
 	resamplingB = new QComboBox;
 	resamplingB->addItems(QStringList() << "Nearest" << "Linear" << "Spline" << "FIR");
 	resamplingB->setCurrentIndex(sets().getInt("ModplugResamplingMethod"));
@@ -76,10 +74,9 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 		sets().set("ModplugResamplingMethod", 3);
 	}
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(enabledB, 0, 0, 1, 2);
-	layout->addWidget(resamplingL, 1, 0, 1, 1);
-	layout->addWidget(resamplingB, 1, 1, 1, 1);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(enabledB);
+	layout->addRow(tr("Resampling method") + ": ", resamplingB);
 }
 
 void ModuleSettingsWidget::saveSettings()

--- a/src/modules/PortAudio/PortAudio.cpp
+++ b/src/modules/PortAudio/PortAudio.cpp
@@ -62,7 +62,7 @@ QMPLAY2_EXPORT_PLUGIN(PortAudio)
 /**/
 
 #include <QDoubleSpinBox>
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QPushButton>
 #include <QComboBox>
 #include <QCheckBox>
@@ -74,15 +74,11 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	enabledB = new QCheckBox(tr("Enabled"));
 	enabledB->setChecked(sets().getBool("WriterEnabled"));
 
-	QLabel *delayL = new QLabel(tr("Delay") + ": ");
-
 	delayB = new QDoubleSpinBox;
 	delayB->setRange(0.01, 1.0);
 	delayB->setSingleStep(0.01);
 	delayB->setSuffix(" " + tr("sec"));
 	delayB->setValue(sets().getDouble("Delay"));
-
-	QLabel *devicesL = new QLabel(tr("Playback device") + ": ");
 
 	devicesB = new QComboBox;
 	devicesB->addItems(QStringList(tr("Default")) + PortAudioCommon::getOutputDeviceNames());
@@ -93,13 +89,11 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	defaultDevs->setText(tr("Find default output device"));
 	connect(defaultDevs, SIGNAL(clicked()), this, SLOT(defaultDevs()));
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(enabledB, 0, 0, 1, 2);
-	layout->addWidget(devicesL, 1, 0, 1, 1);
-	layout->addWidget(devicesB, 1, 1, 1, 1);
-	layout->addWidget(defaultDevs, 2, 0, 1, 2);
-	layout->addWidget(delayL, 3, 0, 1, 1);
-	layout->addWidget(delayB, 3, 1, 1, 1);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(enabledB);
+	layout->addRow(tr("Playback device") + ": ", devicesB);
+	layout->addRow(defaultDevs);
+	layout->addRow(tr("Delay") + ": ", delayB);
 }
 
 void ModuleSettingsWidget::defaultDevs()

--- a/src/modules/PulseAudio/PulseAudio.cpp
+++ b/src/modules/PulseAudio/PulseAudio.cpp
@@ -52,7 +52,7 @@ QMPLAY2_EXPORT_PLUGIN(PulseAudio)
 /**/
 
 #include <QDoubleSpinBox>
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QCheckBox>
 #include <QLabel>
 
@@ -62,18 +62,15 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	enabledB = new QCheckBox(tr("Enabled"));
 	enabledB->setChecked(sets().getBool("WriterEnabled"));
 
-	QLabel *delayL = new QLabel(tr("Delay") + ": ");
-
 	delayB = new QDoubleSpinBox;
 	delayB->setRange(0.01, 1.0);
 	delayB->setSingleStep(0.01);
 	delayB->setSuffix(" " + tr("sec"));
 	delayB->setValue(sets().getDouble("Delay"));
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(enabledB, 0, 0, 1, 2);
-	layout->addWidget(delayL, 1, 0, 1, 1);
-	layout->addWidget(delayB, 1, 1, 1, 1);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(enabledB);
+	layout->addRow(tr("Delay") + ": ", delayB);
 }
 
 void ModuleSettingsWidget::saveSettings()

--- a/src/modules/Visualizations/Visualizations.cpp
+++ b/src/modules/Visualizations/Visualizations.cpp
@@ -61,49 +61,37 @@ QMPLAY2_EXPORT_PLUGIN(Visualizations)
 
 /**/
 
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QSpinBox>
 #include <QLabel>
 
 ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	Module::SettingsWidget(module)
 {
-	QLabel *refTimeL = new QLabel(tr("Refresh time") + ": ");
-
 	refTimeB = new QSpinBox;
 	refTimeB->setRange(1, 500);
 	refTimeB->setSuffix(" " + tr("ms"));
 	refTimeB->setValue(sets().getInt("RefreshTime"));
-
-	QLabel *sndLenL = new QLabel(tr("Displayed sound length") + ": ");
 
 	sndLenB = new QSpinBox;
 	sndLenB->setRange(1, 500);
 	sndLenB->setSuffix(" " + tr("ms"));
 	sndLenB->setValue(sets().getInt("SimpleVis/SoundLength"));
 
-	QLabel *fftSizeL = new QLabel(tr("FFT spectrum size") + ": ");
-
 	fftSizeB = new QSpinBox;
 	fftSizeB->setRange(5, 10);
 	fftSizeB->setPrefix("2^");
 	fftSizeB->setValue(sets().getInt("FFTSpectrum/Size"));
 
-	QLabel *fftScaleL = new QLabel(tr("FFT spectrum scale") + ": ");
-
 	fftScaleB = new QSpinBox;
 	fftScaleB->setRange(1, 20);
 	fftScaleB->setValue(sets().getInt("FFTSpectrum/Scale"));
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(refTimeL, 0, 0);
-	layout->addWidget(refTimeB, 0, 1);
-	layout->addWidget(sndLenL, 1, 0);
-	layout->addWidget(sndLenB, 1, 1);
-	layout->addWidget(fftSizeL, 2, 0);
-	layout->addWidget(fftSizeB, 2, 1);
-	layout->addWidget(fftScaleL, 3, 0);
-	layout->addWidget(fftScaleB, 3, 1);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(tr("Refresh time") + ": ", refTimeB);
+	layout->addRow(tr("Displayed sound length") + ": ", sndLenB);
+	layout->addRow(tr("FFT spectrum size") + ": ", fftSizeB);
+	layout->addRow(tr("FFT spectrum scale") + ": ", fftScaleB);
 
 	connect(refTimeB, SIGNAL(valueChanged(int)), sndLenB, SLOT(setValue(int)));
 }

--- a/src/modules/XVideo/XVideo.cpp
+++ b/src/modules/XVideo/XVideo.cpp
@@ -51,7 +51,7 @@ QMPLAY2_EXPORT_PLUGIN(XVideo)
 
 /**/
 
-#include <QGridLayout>
+#include <QFormLayout>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QLabel>
@@ -65,19 +65,16 @@ ModuleSettingsWidget::ModuleSettingsWidget(Module &module) :
 	useSHMB = new QCheckBox(tr("Use shared memory"));
 	useSHMB->setChecked(sets().getBool("UseSHM"));
 
-	QLabel *adaptorsL = new QLabel(tr("XVideo outputs") + ": ");
-
 	adaptorsB = new QComboBox;
 	adaptorsB->addItem(tr("Default"));
 	adaptorsB->addItems(XVIDEO::adaptorsList());
 	int idx = adaptorsB->findText(sets().getString("Adaptor"));
 	adaptorsB->setCurrentIndex(idx < 0 ? 0 : idx);
 
-	QGridLayout *layout = new QGridLayout(this);
-	layout->addWidget(enabledB, 0, 0, 1, 2);
-	layout->addWidget(useSHMB, 1, 0, 1, 2);
-	layout->addWidget(adaptorsL, 2, 0, 1, 1);
-	layout->addWidget(adaptorsB, 2, 1, 1, 1);
+	QFormLayout *layout = new QFormLayout(this);
+	layout->addRow(enabledB);
+	layout->addRow(useSHMB);
+	layout->addRow(tr("XVideo outputs") + ": ", adaptorsB);
 }
 
 void ModuleSettingsWidget::saveSettings()


### PR DESCRIPTION
Many layouts in this project uses a QGridLayout with the format of two columns and while in the first one is a label and another widget on the second column. For those types of types of layouts Qt's documentation recommends using QFormLayout. It has a special function called `addRow` which enables to do the listed before easier. The best way to see the change is in commit 644ea6a316d4e9d1718ed775a67b5687a87469d2.

I changes various layouts (maybe there are more). Before deciding to change a layout I checked if the resulting binary size reduces (no need to manually create a QLabel for example), and if there is performance boost (as QFormLayout is a little simpler for Qt).
The size reduction varied, but the total reduction was around 4KB (on my machine). The performance improvement was around 2%-5% when loading the layout and resizing the containing window.

Also the UI changes were little to none. The modules once were a little easier to read. Appearance, DeintSettingsW and TagEditor didn't change at all for me.

As a result we have smaller size while better time performance, while the code is a little easier to read (less lines, no need to count rows, more grouping of information). Therefore I think this is a good PR to merge (after squashing the commits and removing the "reduces ..." description). 

Also I thought that it isn't about moving to `*.ui` files, therefore I think to target the master branch and not settings-ui.

Also I ask **not to merge** at least until tomorrow (Friday, 2016-04-15) because I want to check other layouts. But I think it is a good idea to start reviewing all those commits now.