### PR TITLE
More Code cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,6 @@ configure_file(
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 
-message("")
+message(STATUS "")
 PRINT_ENABLED_FEATURES()
 PRINT_DISABLED_FEATURES()

--- a/src/gui/AboutWidget.cpp
+++ b/src/gui/AboutWidget.cpp
@@ -150,7 +150,7 @@ void AboutWidget::refreshLog()
 	{
 		QByteArray data = f.readAll();
 		f.close();
-		if (data.right(1) == "\n")
+		if (data.endsWith("\n"))
 			data.chop(1);
 		logE->setPlainText(data);
 		logE->moveCursor(QTextCursor::End);

--- a/src/gui/EntryProperties.cpp
+++ b/src/gui/EntryProperties.cpp
@@ -56,6 +56,7 @@ EntryProperties::EntryProperties(QWidget *p, QTreeWidgetItem *_tWI, bool &sync, 
 	setWindowTitle(tr("Properties"));
 
 	QGridLayout layout(this);
+	int row = 0;
 
 	nameE = new QLineEdit;
 	nameE->setText(tWI->text(0));
@@ -72,9 +73,8 @@ EntryProperties::EntryProperties(QWidget *p, QTreeWidgetItem *_tWI, bool &sync, 
 
 		nameE->selectAll();
 
-		catalogCB = new QCheckBox;
+		catalogCB = new QCheckBox(tr("Synchronize with file or directory"));
 		catalogCB->setChecked(!pthE->text().isEmpty());
-		catalogCB->setText(tr("Synchronize with file or directory"));
 		connect(catalogCB, SIGNAL(stateChanged(int)), this, SLOT(setDirPthEEnabled(int)));
 
 		browseDirB = new QToolButton;
@@ -88,48 +88,40 @@ EntryProperties::EntryProperties(QWidget *p, QTreeWidgetItem *_tWI, bool &sync, 
 		connect(browseFileB, SIGNAL(clicked()), this, SLOT(browse()));
 
 		setDirPthEEnabled(catalogCB->isChecked());
+
+		layout.addWidget(nameE, row++, 0, 1, 3);
+		layout.addWidget(catalogCB, row++, 0, 1, 1);
+		layout.addWidget(pthE, row, 0, 1, 1);
+		layout.addWidget(browseDirB, row, 1, 1, 1);
+		layout.addWidget(browseFileB, row, 2, 1, 1);
 	}
 	else
 	{
+		nameE->setReadOnly(true);
+		layout.addWidget(nameE, row++, 0, 1, 1);
+
 		addrB = new AddressBox(Qt::Horizontal, url);
+		layout.addWidget(addrB, row, 0, 1, 1);
 
 #ifdef QMPlay2_TagEditor
 		tagEditor = new TagEditor;
 		connect(addrB, SIGNAL(directAddressChanged()), this, SLOT(directAddressChanged()));
 		directAddressChanged();
+		layout.addWidget(tagEditor, ++row, 0, 1, 1);
 #endif
 
 		QFileInfo fi(addrB->cleanUrl());
 		if (fi.isFile())
+		{
 			fileSizeL = new QLabel(tr("File size") + ": " + Functions::sizeString(fi.size()));
-
-		nameE->setReadOnly(true);
+			layout.addWidget(fileSizeL, ++row, 0, 1, 1);
+		}
 	}
 
-	QDialogButtonBox *buttonBox = new QDialogButtonBox;
-	buttonBox->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+	QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 	connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
 	connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
 
-	int row = 0;
-	layout.addWidget(nameE, row++, 0, 1, (browseDirB && browseFileB) ? 3 : 1);
-	if (catalogCB)
-		layout.addWidget(catalogCB, row++, 0, 1, 1);
-	if (addrB)
-		layout.addWidget(addrB, row, 0, 1, 1);
-#ifdef QMPlay2_TagEditor
-	if (tagEditor)
-		layout.addWidget(tagEditor, ++row, 0, 1, 1);
-#endif
-	if (fileSizeL)
-		layout.addWidget(fileSizeL, ++row, 0, 1, 1);
-	if (pthE)
-		layout.addWidget(pthE, row, 0, 1, 1);
-	if (browseDirB && browseFileB)
-	{
-		layout.addWidget(browseDirB, row, 1, 1, 1);
-		layout.addWidget(browseFileB, row, 2, 1, 1);
-	}
 #ifdef QMPlay2_TagEditor
 	if (!tagEditor)
 #endif

--- a/src/gui/EntryProperties.cpp
+++ b/src/gui/EntryProperties.cpp
@@ -58,8 +58,7 @@ EntryProperties::EntryProperties(QWidget *p, QTreeWidgetItem *_tWI, bool &sync, 
 	QGridLayout layout(this);
 	int row = 0;
 
-	nameE = new QLineEdit;
-	nameE->setText(tWI->text(0));
+	nameE = new QLineEdit(tWI->text(0));
 
 	QString url = tWI->data(0, Qt::UserRole).toString();
 	if (url.startsWith("file://"))
@@ -67,8 +66,7 @@ EntryProperties::EntryProperties(QWidget *p, QTreeWidgetItem *_tWI, bool &sync, 
 
 	if (PlaylistWidget::isGroup(tWI))
 	{
-		pthE = new QLineEdit;
-		pthE->setText(url);
+		pthE = new QLineEdit(url);
 		origDirPth = url;
 
 		nameE->selectAll();

--- a/src/gui/InfoDock.cpp
+++ b/src/gui/InfoDock.cpp
@@ -38,12 +38,12 @@ void TextEdit::mousePressEvent(QMouseEvent *e)
 		if (!anchor.isEmpty())
 		{
 			InfoDock *infoD = (InfoDock *)parent()->parent();
-			if (anchor.left(5) == "seek:")
+			if (anchor.startsWith("seek:"))
 			{
 				anchor.remove(0, 5);
 				emit infoD->seek(anchor.toDouble());
 			}
-			else if (anchor.left(7) == "stream:")
+			else if (anchor.startsWith("stream:"))
 			{
 				anchor.remove(0, 7);
 				emit infoD->chStream(anchor);

--- a/src/gui/InfoDock.hpp
+++ b/src/gui/InfoDock.hpp
@@ -22,7 +22,6 @@
 
 class TextEdit : public QTextEdit
 {
-	Q_OBJECT
 private:
 	void mouseMoveEvent(QMouseEvent *);
 	void mousePressEvent(QMouseEvent *);

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -336,7 +336,7 @@ static bool writeToSocket(QLocalSocket &socket)
 			if (!QMPArguments.second[i].isEmpty())
 				QMPArguments.second[i] = Functions::Url(QMPArguments.second[i]);
 #ifdef Q_OS_WIN
-			if (QMPArguments.second[i].left(7) == "file://")
+			if (QMPArguments.second[i].startsWith("file://"))
 				QMPArguments.second[i].remove(0, 7);
 #endif
 		}
@@ -620,7 +620,7 @@ int main(int argc, char *argv[])
 
 #ifdef UPDATER
 		QString UpdateFile = settings.getString("UpdateFile");
-		if (UpdateFile.left(7) == "remove:")
+		if (UpdateFile.startsWith("remove:"))
 		{
 			UpdateFile.remove(0, 7);
 			if (lastVer != QMPlay2Version)

--- a/src/gui/MainWidget.cpp
+++ b/src/gui/MainWidget.cpp
@@ -161,7 +161,7 @@ MainWidget::MainWidget(QPair<QStringList, QStringList> &QMPArguments)
 	statusBar->setSizeGripEnabled(false);
 	timeL = new QLabel;
 	statusBar->addPermanentWidget(timeL);
-	stateL = new QLabel(tr("Stopped"));
+	QLabel *stateL = new QLabel(tr("Stopped"));
 	statusBar->addWidget(stateL);
 	setStatusBar(statusBar);
 

--- a/src/gui/MainWidget.hpp
+++ b/src/gui/MainWidget.hpp
@@ -136,7 +136,7 @@ private:
 	QStatusBar *statusBar;
 
 	QFrame *vLine;
-	QLabel *timeL, *stateL;
+	QLabel *timeL;
 
 	VideoDock *videoDock;
 	InfoDock *infoDock;

--- a/src/gui/PlayClass.cpp
+++ b/src/gui/PlayClass.cpp
@@ -95,7 +95,7 @@
 #endif
 
 PlayClass::PlayClass() :
-	demuxThr(NULL), vThr(NULL), aThr(NULL),
+	demuxThr(NULL), vThr(NULL), aThr(NULL), aRatioName("auto"),
 #if defined Q_OS_WIN && !defined Q_OS_WIN64
 	firsttimeUpdateCache(true),
 #endif
@@ -108,7 +108,6 @@ PlayClass::PlayClass() :
 
 	quitApp = muted = reload = false;
 
-	aRatioName = "auto";
 	speed = subtitlesScale = zoom = 1.0;
 	flip = 0;
 	rotate90 = spherical = false;

--- a/src/gui/PlayClass.cpp
+++ b/src/gui/PlayClass.cpp
@@ -95,7 +95,8 @@
 #endif
 
 PlayClass::PlayClass() :
-	demuxThr(NULL), vThr(NULL), aThr(NULL), aRatioName("auto"),
+	demuxThr(NULL), vThr(NULL), aThr(NULL),
+	aRatioName("auto"),
 #if defined Q_OS_WIN && !defined Q_OS_WIN64
 	firsttimeUpdateCache(true),
 #endif
@@ -300,13 +301,13 @@ void PlayClass::seek(int pos)
 }
 void PlayClass::chStream(const QString &s)
 {
-	if (s.left(5) == "audio")
+	if (s.startsWith("audio"))
 		choosenAudioStream = s.right(s.length() - 5).toInt();
-	else if (s.left(5) == "video")
+	else if (s.startsWith("video"))
 		choosenVideoStream = s.right(s.length() - 5).toInt();
-	else if (s.left(9) == "subtitles")
+	else if (s.startsWith("subtitles"))
 		choosenSubtitlesStream = s.right(s.length() - 9).toInt();
-	else if (s.left(8) == "fileSubs")
+	else if (s.startsWith("fileSubs"))
 	{
 		int idx = s.right(s.length() - 8).toInt();
 		if (fileSubsList.count() > idx)

--- a/src/gui/PlaylistDock.cpp
+++ b/src/gui/PlaylistDock.cpp
@@ -47,7 +47,7 @@ PlaylistDock::PlaylistDock() :
 	findE->setToolTip(tr("Filter entries"));
 	statusL = new QLabel;
 
-	layout = new QGridLayout(&mainW);
+	QGridLayout *layout = new QGridLayout(&mainW);
 	layout->addWidget(list);
 	layout->addWidget(findE);
 	layout->addWidget(statusL);

--- a/src/gui/PlaylistDock.cpp
+++ b/src/gui/PlaylistDock.cpp
@@ -541,7 +541,7 @@ void PlaylistDock::syncCurrentFolder()
 		tWI->setIcon(0, *QMPlay2GUI.groupIcon);
 		return;
 	}
-	if (pthInfo.isDir() && pth.right(1) != "/")
+	if (pthInfo.isDir() && !pth.endsWith("/"))
 		pth += "/";
 	findE->clear();
 	list->sync(pth, tWI, !pthInfo.isDir() && (possibleModuleScheme || pthInfo.isFile()));

--- a/src/gui/PlaylistDock.hpp
+++ b/src/gui/PlaylistDock.hpp
@@ -21,7 +21,6 @@
 
 class QTreeWidgetItem;
 class PlaylistWidget;
-class QGridLayout;
 class LineEdit;
 class QLabel;
 
@@ -56,7 +55,6 @@ private:
 	inline bool isRandomPlayback() const;
 
 	QWidget mainW;
-	QGridLayout *layout;
 	PlaylistWidget *list;
 	QLabel *statusL;
 	LineEdit *findE;

--- a/src/gui/Updater.cpp
+++ b/src/gui/Updater.cpp
@@ -165,7 +165,7 @@ void Updater::writeToFile()
 	bool err = false;
 	if (firstChunk)
 	{
-		err = (arr.left(2) != "MZ");
+                err = (!arr.startsWith("MZ"));
 		firstChunk = false;
 	}
 	if (err || updateFile.write(arr) != arr.size())

--- a/src/gui/Updater.cpp
+++ b/src/gui/Updater.cpp
@@ -165,7 +165,7 @@ void Updater::writeToFile()
 	bool err = false;
 	if (firstChunk)
 	{
-                err = (!arr.startsWith("MZ"));
+		err = !arr.startsWith("MZ");
 		firstChunk = false;
 	}
 	if (err || updateFile.write(arr) != arr.size())

--- a/src/gui/VideoAdjustment.cpp
+++ b/src/gui/VideoAdjustment.cpp
@@ -47,7 +47,7 @@ static const char *ControlsNames[CONTROLS_COUNT] = {
 };
 
 VideoAdjustment::VideoAdjustment() :
-	sliders(new Slider*[CONTROLS_COUNT])
+	sliders(new Slider[CONTROLS_COUNT])
 {
 	QGridLayout *layout = new QGridLayout;
 	int i;
@@ -59,18 +59,17 @@ VideoAdjustment::VideoAdjustment() :
 
 		QLabel *valueL = new QLabel("0");
 
-		Slider *slider = sliders[i] = new Slider;
-		slider->setProperty("valueL", qVariantFromValue((void *)valueL));
-		slider->setTickPosition(QSlider::TicksBelow);
-		slider->setMinimumWidth(50);
-		slider->setTickInterval(25);
-		slider->setRange(-100, 100);
-		slider->setWheelStep(1);
-		slider->setValue(0);
-		connect(slider, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
+		sliders[i].setProperty("valueL", qVariantFromValue((void *)valueL));
+		sliders[i].setTickPosition(QSlider::TicksBelow);
+		sliders[i].setMinimumWidth(50);
+		sliders[i].setTickInterval(25);
+		sliders[i].setRange(-100, 100);
+		sliders[i].setWheelStep(1);
+		sliders[i].setValue(0);
+		connect(&sliders[i], SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
 
 		layout->addWidget(titleL, i, 0);
-		layout->addWidget(slider, i, 1);
+		layout->addWidget(&sliders[i], i, 1);
 		layout->addWidget(valueL, i, 2);
 	}
 
@@ -90,27 +89,27 @@ VideoAdjustment::~VideoAdjustment()
 void VideoAdjustment::restoreValues()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		sliders[i]->setValue(QMPlay2Core.getSettings().getInt(QString("VideoAdjustment/") + ControlsNames[i]));
+		sliders[i].setValue(QMPlay2Core.getSettings().getInt(QString("VideoAdjustment/") + ControlsNames[i]));
 }
 void VideoAdjustment::saveValues()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		QMPlay2Core.getSettings().set(QString("VideoAdjustment/") + ControlsNames[i], sliders[i]->value());
+		QMPlay2Core.getSettings().set(QString("VideoAdjustment/") + ControlsNames[i], sliders[i].value());
 }
 
 void VideoAdjustment::setModuleParam(ModuleParams *writer)
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
 	{
-		sliders[i]->setEnabled(writer->hasParam(ControlsNames[i]));
-		writer->modParam(ControlsNames[i], sliders[i]->value());
+		sliders[i].setEnabled(writer->hasParam(ControlsNames[i]));
+		writer->modParam(ControlsNames[i], sliders[i].value());
 	}
 }
 
 void VideoAdjustment::enableControls()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		sliders[i]->setEnabled(true);
+		sliders[i].setEnabled(true);
 }
 
 void VideoAdjustment::setValue(int v)
@@ -121,5 +120,5 @@ void VideoAdjustment::setValue(int v)
 void VideoAdjustment::reset()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		sliders[i]->setValue(0);
+		sliders[i].setValue(0);
 }

--- a/src/gui/VideoAdjustment.cpp
+++ b/src/gui/VideoAdjustment.cpp
@@ -47,22 +47,19 @@ static const char *ControlsNames[CONTROLS_COUNT] = {
 };
 
 VideoAdjustment::VideoAdjustment() :
-	layout(new QGridLayout),
-	controls(new Controls[CONTROLS_COUNT])
+	sliders(new Slider*[CONTROLS_COUNT])
 {
+	QGridLayout *layout = new QGridLayout;
 	int i;
 	for (i = 0; i < CONTROLS_COUNT; ++i)
 	{
-		QLabel *&titleL = controls[i].titleL;
-		QLabel *&valueL = controls[i].valueL;
-		Slider *&slider = controls[i].slider;
 
-		titleL = new QLabel(tr(ControlsNames[i]) + ": ");
+		QLabel *titleL = new QLabel(tr(ControlsNames[i]) + ": ");
 		titleL->setAlignment(Qt::AlignRight);
 
-		valueL = new QLabel("0");
+		QLabel *valueL = new QLabel("0");
 
-		slider = new Slider;
+		Slider *slider = sliders[i] = new Slider;
 		slider->setProperty("valueL", qVariantFromValue((void *)valueL));
 		slider->setTickPosition(QSlider::TicksBelow);
 		slider->setMinimumWidth(50);
@@ -70,15 +67,14 @@ VideoAdjustment::VideoAdjustment() :
 		slider->setRange(-100, 100);
 		slider->setWheelStep(1);
 		slider->setValue(0);
+		connect(slider, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
 
 		layout->addWidget(titleL, i, 0);
 		layout->addWidget(slider, i, 1);
 		layout->addWidget(valueL, i, 2);
-
-		connect(slider, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
 	}
 
-	resetB = new QPushButton(tr("Reset"));
+	QPushButton *resetB = new QPushButton(tr("Reset"));
 	connect(resetB, SIGNAL(clicked()), this, SLOT(reset()));
 
 	layout->addWidget(resetB, i++, 0, 1, 3);
@@ -88,33 +84,33 @@ VideoAdjustment::VideoAdjustment() :
 }
 VideoAdjustment::~VideoAdjustment()
 {
-	delete[] controls;
+	delete[] sliders;
 }
 
 void VideoAdjustment::restoreValues()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		controls[i].slider->setValue(QMPlay2Core.getSettings().getInt(QString("VideoAdjustment/") + ControlsNames[i]));
+		sliders[i]->setValue(QMPlay2Core.getSettings().getInt(QString("VideoAdjustment/") + ControlsNames[i]));
 }
 void VideoAdjustment::saveValues()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		QMPlay2Core.getSettings().set(QString("VideoAdjustment/") + ControlsNames[i], controls[i].slider->value());
+		QMPlay2Core.getSettings().set(QString("VideoAdjustment/") + ControlsNames[i], sliders[i]->value());
 }
 
 void VideoAdjustment::setModuleParam(ModuleParams *writer)
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
 	{
-		controls[i].slider->setEnabled(writer->hasParam(ControlsNames[i]));
-		writer->modParam(ControlsNames[i], controls[i].slider->value());
+		sliders[i]->setEnabled(writer->hasParam(ControlsNames[i]));
+		writer->modParam(ControlsNames[i], sliders[i]->value());
 	}
 }
 
 void VideoAdjustment::enableControls()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		controls[i].slider->setEnabled(true);
+		sliders[i]->setEnabled(true);
 }
 
 void VideoAdjustment::setValue(int v)
@@ -125,5 +121,5 @@ void VideoAdjustment::setValue(int v)
 void VideoAdjustment::reset()
 {
 	for (int i = 0; i < CONTROLS_COUNT; ++i)
-		controls[i].slider->setValue(0);
+		sliders[i]->setValue(0);
 }

--- a/src/gui/VideoAdjustment.cpp
+++ b/src/gui/VideoAdjustment.cpp
@@ -59,17 +59,18 @@ VideoAdjustment::VideoAdjustment() :
 
 		QLabel *valueL = new QLabel("0");
 
-		sliders[i].setProperty("valueL", qVariantFromValue((void *)valueL));
-		sliders[i].setTickPosition(QSlider::TicksBelow);
-		sliders[i].setMinimumWidth(50);
-		sliders[i].setTickInterval(25);
-		sliders[i].setRange(-100, 100);
-		sliders[i].setWheelStep(1);
-		sliders[i].setValue(0);
-		connect(&sliders[i], SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
+		Slider *slider = &sliders[i];
+		slider->setProperty("valueL", qVariantFromValue((void *)valueL));
+		slider->setTickPosition(QSlider::TicksBelow);
+		slider->setMinimumWidth(50);
+		slider->setTickInterval(25);
+		slider->setRange(-100, 100);
+		slider->setWheelStep(1);
+		slider->setValue(0);
+		connect(slider, SIGNAL(valueChanged(int)), this, SLOT(setValue(int)));
 
 		layout->addWidget(titleL, i, 0);
-		layout->addWidget(&sliders[i], i, 1);
+		layout->addWidget(slider, i, 1);
 		layout->addWidget(valueL, i, 2);
 	}
 

--- a/src/gui/VideoAdjustment.hpp
+++ b/src/gui/VideoAdjustment.hpp
@@ -22,9 +22,6 @@
 #include <QWidget>
 
 class ModuleParams;
-class QGridLayout;
-class QPushButton;
-class QLabel;
 class Slider;
 
 class VideoAdjustment : public QWidget
@@ -45,13 +42,7 @@ private slots:
 	void setValue(int);
 	void reset();
 private:
-	QGridLayout *layout;
-	struct Controls
-	{
-		QLabel *titleL, *valueL;
-		Slider *slider;
-	} *controls;
-	QPushButton *resetB;
+	Slider **sliders;
 };
 
 #endif //VIDEOADJUSTMENT_HPP

--- a/src/gui/VideoAdjustment.hpp
+++ b/src/gui/VideoAdjustment.hpp
@@ -42,7 +42,7 @@ private slots:
 	void setValue(int);
 	void reset();
 private:
-	Slider **sliders;
+	Slider *sliders;
 };
 
 #endif //VIDEOADJUSTMENT_HPP

--- a/src/modules/Extensions/Radio.cpp
+++ b/src/modules/Extensions/Radio.cpp
@@ -166,7 +166,7 @@ void Radio::finished()
 	if (!netReply->error())
 	{
 		QByteArray RadioList = netReply->readAll();
-		if (RadioList.left(4) != "NXRL")
+		if (!RadioList.startsWith("NXRL"))
 			err = true;
 		else
 		{
@@ -174,7 +174,7 @@ void Radio::finished()
 			QString GroupName;
 			while (RadioList.size())
 			{
-				if (RadioList.left(4) == "NXRL")
+				if (RadioList.startsWith("NXRL"))
 				{
 					RadioList.remove(0, 4);
 					GroupName = RadioList.data();

--- a/src/modules/FFmpeg/FFCommon.cpp
+++ b/src/modules/FFmpeg/FFCommon.cpp
@@ -34,10 +34,10 @@ QString FFCommon::prepareUrl(QString url, AVDictionary *&options)
 		url.remove(0, 7);
 	else
 	{
-		if (url.left(4) == "mms:")
+		if (url.startsWith("mms:"))
 			url.insert(3, 'h');
 #if LIBAVFORMAT_VERSION_MAJOR <= 55
-		if (url.left(4) == "http")
+		if (url.startsWith("http"))
 			av_dict_set(&options, "icy", "1", 0);
 #endif
 		av_dict_set(&options, "user-agent", QMPlay2UserAgent, 0);

--- a/src/modules/FFmpeg/FormatContext.cpp
+++ b/src/modules/FFmpeg/FormatContext.cpp
@@ -726,9 +726,9 @@ bool FormatContext::open(const QString &_url, const QString &param)
 		av_free(value);
 		foreach (const QString &icy, icyHeaders)
 		{
-			if (icy.left(10) == "icy-name: ")
+			if (icy.startsWith("icy-name: "))
 				av_dict_set(&formatCtx->metadata, "icy-name", icy.mid(10).toUtf8(), 0);
-			else if (icy.left(17) == "icy-description: ")
+			else if (icy.startsWith("icy-description: "))
 				av_dict_set(&formatCtx->metadata, "icy-description", icy.mid(17).toUtf8(), 0);
 		}
 		metadata = getMetadata();

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -158,7 +158,7 @@ QString Functions::fileName(QString f, bool extension)
 #endif
 	while (f.endsWith("/"))
 		f.chop(1);
-	QString n = f.right(f.length() - f.lastIndexOf('/') - 1);
+	const QString n = f.right(f.length() - f.lastIndexOf('/') - 1);
 	if (extension || !f.startsWith("file://"))
 		return n;
 	return n.mid(0, n.lastIndexOf('.'));

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -62,17 +62,17 @@ QString Functions::Url(QString url, const QString &pth)
 #endif
 	QString scheme = getUrlScheme(url);
 #ifdef Q_OS_WIN
-	if (url.left(8) == "file:///") //lokalnie na dysku
+	if (url.startsWith("file:///")) //lokalnie na dysku
 	{
 		url.remove(7, 1);
 		return url;
 	}
-	else if (url.left(7) == "file://") //adres sieciowy
+	else if (url.startsWith("file://")) //adres sieciowy
 	{
 		url.replace("file://", "file:////");
 		return url;
 	}
-	if (url.left(2) == "//") //adres sieciowy
+	if (url.startsWith("//")) //adres sieciowy
 	{
 		url.prepend("file://");
 		return url;
@@ -91,15 +91,15 @@ QString Functions::Url(QString url, const QString &pth)
 	if (scheme.isEmpty())
 	{
 #ifdef Q_OS_WIN
-		if (url.left(1) == "/")
+		if (url.startsWith("/"))
 			url.remove(0, 1);
 #endif
 #ifndef Q_OS_WIN
-		if (url.left(1) != "/")
+		if (!url.startsWith("/"))
 #endif
 		{
 			QString addPth = pth.isEmpty() ? QDir::currentPath() : pth;
-			if (addPth.right(1) != "/")
+			if (!addPth.endsWith("/"))
 				addPth += '/';
 			url.prepend(addPth);
 		}
@@ -156,7 +156,7 @@ QString Functions::fileName(QString f, bool extension)
 	if (f == "file:///")
 		return "/";
 #endif
-	while (f.right(1) == "/")
+	while (f.endsWith("/"))
 		f.chop(1);
 	QString n = f.right(f.length() - f.lastIndexOf('/') - 1);
 	if (extension || !f.startsWith("file://"))
@@ -177,9 +177,9 @@ QString Functions::cleanPath(QString p)
 	if (p == "file:///")
 		return p;
 #endif
-	if (p.right(1) != "/")
+	if (!p.endsWith("/"))
 		return p + "/";
-	while (p.right(2) == "//")
+	while (p.endsWith("//"))
 		p.chop(1);
 	return p;
 }
@@ -419,7 +419,7 @@ QStringList Functions::getUrlsFromMimeData(const QMimeData *mimeData)
 		foreach (const QUrl &url, mimeData->urls())
 		{
 			QString u = url.toLocalFile();
-			if (u.length() > 1 && u.right(1) == "/")
+			if (u.length() > 1 && u.endsWith("/"))
 				u.chop(1);
 			if (!u.isEmpty())
 				urls += u;


### PR DESCRIPTION
Well, I continue checking various parts of the code, trying to clean it, reorganizing and etc.

1. patch 211a58160a577614aee211352c77dec8e2eaf692 - print this new line as STATUS variable, making it better outputted when there are filters on CMake output (PRINT_ENABLED_FEATURES function uses STATUS internally).

2. patch 02ce6263841a167a45f9d7359d3fd92003377aba - the buttons, labels and layout are only needed as variables during initialization, therefore use them as local variable in ctor. Because after removing labels the `struct Controls` is only of `Slider*`, I changed the `controls` to array of `Slider*`. Thus it resulted in double pointer. This is "scary" only in the header file (I hope this is OK with you).

3. patch c845f818bc3a531d727f2cdb3da65265911ab013 - in the EntryProperties class, I move the layout widgets adding to be a part in the if/else block. Thus the amount of ifs that was there before was removed.

4. patch 456e8b002ddb926e4f7cd01df52da29320e201b4 - remove the `Q_OBJECT` from TextEdit. This macro adds a lot of Qt specific code for signals and slot in the same class support. Removing this macro doesn't do any regression from my tests. Only possible point is Qt4.

5. patch 7462d1e61f69b3ca28d5f54dd588bcaaa1dd6e5a - use QString::startsWith

The purpose of those various commits from the various pull requests is to optimize QMPlay2, make it's code cleaner, make the code shorter.