### PR TITLE
Shortcuts Editor in Settings

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -38,6 +38,7 @@ set(GUI_HDR
     VolWidget.hpp
     ScreenSaver.hpp
     ShortcutHandler.hpp
+    KeyBindingsDialog.hpp
 )
 
 set(GUI_SRC
@@ -66,6 +67,7 @@ set(GUI_SRC
     VolWidget.cpp
     ScreenSaver.cpp
     ShortcutHandler.cpp
+    KeyBindingsDialog.cpp
 )
 
 set(GUI_FORMS # *.ui files

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -37,6 +37,7 @@ set(GUI_HDR
     Appearance.hpp
     VolWidget.hpp
     ScreenSaver.hpp
+    ShortcutHandler.hpp
 )
 
 set(GUI_SRC
@@ -64,6 +65,7 @@ set(GUI_SRC
     Appearance.cpp
     VolWidget.cpp
     ScreenSaver.cpp
+    ShortcutHandler.cpp
 )
 
 set(GUI_FORMS # *.ui files

--- a/src/gui/KeyBindingsDialog.cpp
+++ b/src/gui/KeyBindingsDialog.cpp
@@ -1,0 +1,82 @@
+/*
+	QMPlay2 is a video and audio player.
+	Copyright (C) 2010-2016  Błażej Szczygieł
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <KeyBindingsDialog.hpp>
+#include <ShortcutHandler.hpp>
+#include <Main.hpp>
+#include <Settings.hpp>
+
+#include <QBoxLayout>
+#include <QDialogButtonBox>
+#include <QTableView>
+#include <QHeaderView>
+
+KeyBindingsDialog::KeyBindingsDialog(QWidget *p) :
+	QDialog(p)
+{
+	setWindowTitle(tr("Key Binding settings"));
+
+	QTableView *shortcuts = new QTableView(this);
+	shortcuts->setModel(ShortcutHandler::instance());
+	shortcuts->setFrameShape(QFrame::NoFrame);
+	shortcuts->setAlternatingRowColors(true);
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+	shortcuts->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+	shortcuts->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+#else
+	shortcuts->horizontalHeader()->setResizeMode(0, QHeaderView::ResizeToContents);
+	shortcuts->horizontalHeader()->setResizeMode(1, QHeaderView::Stretch);
+#endif
+	shortcuts->verticalHeader()->setVisible(false);
+
+	buttons = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Apply | QDialogButtonBox::RestoreDefaults, this);
+	connect(buttons, SIGNAL(clicked(QAbstractButton*)), this, SLOT(clicked(QAbstractButton*)));
+
+	QVBoxLayout *layout = new QVBoxLayout(this);
+	layout->addWidget(shortcuts);
+	layout->addWidget(buttons);
+}
+
+void KeyBindingsDialog::clicked(QAbstractButton *button)
+{
+	switch (buttons->buttonRole(button))
+	{
+		case QDialogButtonBox::ApplyRole:
+			ShortcutHandler::instance()->save();
+			break;
+		case QDialogButtonBox::RejectRole:
+			ShortcutHandler::instance()->restore();
+			break;
+		case QDialogButtonBox::ResetRole:
+			ShortcutHandler::instance()->reset();
+			break;
+		default:
+			return;
+	}
+	this->close();
+}
+
+void KeyBindingsDialog::showEvent(QShowEvent *)
+{
+	QMPlay2GUI.restoreGeometry("KeyBindingsDialog/Geometry", this, QSize(450, 450));
+}
+
+void KeyBindingsDialog::closeEvent(QCloseEvent *)
+{
+	QMPlay2Core.getSettings().set("KeyBindingsDialog/Geometry", geometry());
+}

--- a/src/gui/KeyBindingsDialog.hpp
+++ b/src/gui/KeyBindingsDialog.hpp
@@ -1,0 +1,41 @@
+/*
+	QMPlay2 is a video and audio player.
+	Copyright (C) 2010-2016  Błażej Szczygieł
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef KEYBINDINGDIALOG_HPP
+#define KEYBINDINGDIALOG_HPP
+
+#include <QDialog>
+
+class QAbstractButton;
+class QDialogButtonBox;
+
+class KeyBindingsDialog : public QDialog
+{
+		Q_OBJECT
+	public:
+		KeyBindingsDialog(QWidget *p);
+	private slots:
+		void clicked(QAbstractButton *button);
+	private:
+		void showEvent(QShowEvent *);
+		void closeEvent(QCloseEvent *);
+
+		QDialogButtonBox *buttons;
+};
+
+#endif

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -22,6 +22,7 @@
 #include <DockWidget.hpp>
 #include <Settings.hpp>
 #include <Main.hpp>
+#include <ShortcutHandler.hpp>
 
 #include <QWidgetAction>
 #include <QMainWindow>
@@ -37,115 +38,6 @@ static QAction *newAction(const QString &txt, QMenu *parent, QAction *&act, bool
 }
 
 /**/
-
-void MenuBar::init()
-{
-	Settings &settings = QMPlay2Core.getSettings();
-
-	settings.init("KeyBindings/Window-toggleVisibility", "`");
-	settings.init("KeyBindings/Window-toggleFullScreen", "F");
-	settings.init("KeyBindings/Window-toggleCompactView", "Alt+V");
-	settings.init("KeyBindings/Window-close", "Alt+F4");
-
-
-	settings.init("KeyBindings/Widgets-hideMenu", "Alt+Ctrl+M");
-	settings.init("KeyBindings/Widgets-lockWidgets", "Shift+L");
-
-
-	settings.init("KeyBindings/Playlist-stopLoading", "F4");
-	settings.init("KeyBindings/Playlist-sync", "F5");
-	settings.init("KeyBindings/Playlist-loadPlist", "Ctrl+L");
-	settings.init("KeyBindings/Playlist-savePlist", "Ctrl+S");
-	settings.init("KeyBindings/Playlist-saveGroup", "Ctrl+Shift+S");
-	settings.init("KeyBindings/Playlist-delEntries", "Del");
-	settings.init("KeyBindings/Playlist-delNonGroupEntries", "Ctrl+Del");
-	settings.init("KeyBindings/Playlist-clear", "Shift+Del");
-	settings.init("KeyBindings/Playlist-copy", "Ctrl+C");
-	settings.init("KeyBindings/Playlist-paste", "Ctrl+V");
-	settings.init("KeyBindings/Playlist-newGroup", "F7");
-	settings.init("KeyBindings/Playlist-renameGroup", "F2");
-	settings.init("KeyBindings/Playlist-find", "Ctrl+F");
-	settings.init("KeyBindings/Playlist-collapseAll", "");
-	settings.init("KeyBindings/Playlist-expandAll", "");
-	settings.init("KeyBindings/Playlist-goToPlayback", "Ctrl+P");
-	settings.init("KeyBindings/Playlist-queue", "Q");
-	settings.init("KeyBindings/Playlist-entryProperties", "Alt+Return");
-
-	settings.init("KeyBindings/Playlist-Add-file", "Ctrl+I");
-	settings.init("KeyBindings/Playlist-Add-dir", "Ctrl+D");
-	settings.init("KeyBindings/Playlist-Add-address", "Ctrl+U");
-
-	settings.init("KeyBindings/Playlist-Sort-timeSort1", "");
-	settings.init("KeyBindings/Playlist-Sort-timeSort2", "");
-	settings.init("KeyBindings/Playlist-Sort-titleSort1", "");
-	settings.init("KeyBindings/Playlist-Sort-titleSort2", "");
-
-
-	settings.init("KeyBindings/Player-togglePlay", "Space");
-	settings.init("KeyBindings/Player-stop", "V");
-	settings.init("KeyBindings/Player-next", "B");
-	settings.init("KeyBindings/Player-prev", "Z");
-	settings.init("KeyBindings/Player-nextFrame", ".");
-	settings.init("KeyBindings/Player-abRepeat", "Ctrl+-");
-	settings.init("KeyBindings/Player-seekF", "Right");
-	settings.init("KeyBindings/Player-seekB", "Left");
-	settings.init("KeyBindings/Player-lSeekF", "Up");
-	settings.init("KeyBindings/Player-lSeekB", "Down");
-	settings.init("KeyBindings/Player-speedUp", "]");
-	settings.init("KeyBindings/Player-slowDown", "[");
-	settings.init("KeyBindings/Player-setSpeed", "Shift+S");
-	settings.init("KeyBindings/Player-zoomIn", "E");
-	settings.init("KeyBindings/Player-zoomOut", "W");
-	settings.init("KeyBindings/Player-switchARatio", "A");
-	settings.init("KeyBindings/Player-reset", "R");
-	settings.init("KeyBindings/Player-volUp", "*");
-	settings.init("KeyBindings/Player-volDown", "/");
-	settings.init("KeyBindings/Player-toggleMute", "M");
-	settings.init("KeyBindings/Player-detach", "");
-	settings.init("KeyBindings/Player-suspend", "");
-
-	settings.init("KeyBindings/Player-Repeat-RepeatNormal", "Alt+0");
-	settings.init("KeyBindings/Player-Repeat-RepeatEntry", "Alt+1");
-	settings.init("KeyBindings/Player-Repeat-RepeatGroup", "Alt+2");
-	settings.init("KeyBindings/Player-Repeat-RepeatList", "Alt+3");
-	settings.init("KeyBindings/Player-Repeat-RandomMode", "Alt+4");
-	settings.init("KeyBindings/Player-Repeat-RandomGroupMode", "Alt+5");
-	settings.init("KeyBindings/Player-Repeat-RepeatRandom", "Alt+6");
-	settings.init("KeyBindings/Player-Repeat-RepeatRandomGroup", "Alt+7");
-
-
-	settings.init("KeyBindings/Playback-toggleAudio", "D");
-	settings.init("KeyBindings/Playback-toggleVideo", "O");
-	settings.init("KeyBindings/Playback-videoSync", "Shift+O");
-	settings.init("KeyBindings/Playback-slowDownVideo", "-");
-	settings.init("KeyBindings/Playback-speedUpVideo", "+");
-	settings.init("KeyBindings/Playback-toggleSubtitles", "N");
-	settings.init("KeyBindings/Playback-subsFromFile", "Alt+I");
-	settings.init("KeyBindings/Playback-subtitlesSync", "Shift+N");
-	settings.init("KeyBindings/Playback-slowDownSubtitles", "Shift+Z");
-	settings.init("KeyBindings/Playback-speedUpSubtitles", "Shift+X");
-	settings.init("KeyBindings/Playback-biggerSubtitles", "Shift+R");
-	settings.init("KeyBindings/Playback-smallerSubtitles", "Shift+T");
-	settings.init("KeyBindings/Playback-playbackSettings", "Ctrl+Shift+P");
-	settings.init("KeyBindings/Playback-screenShot", "Alt+S");
-
-	settings.init("KeyBindings/Playback-VideoFilters-spherical", "Ctrl+3");
-	settings.init("KeyBindings/Playback-VideoFilters-hFlip", "Ctrl+M");
-	settings.init("KeyBindings/Playback-VideoFilters-vFlip", "Ctrl+R");
-	settings.init("KeyBindings/Playback-VideoFilters-rotate90", "Ctrl+9");
-	settings.init("KeyBindings/Playback-VideoFilters-more", "Alt+F");
-
-
-	settings.init("KeyBindings/Options-settings", "Ctrl+O");
-	settings.init("KeyBindings/Options-modulesSettings", "Ctrl+Shift+O");
-	settings.init("KeyBindings/Options-trayVisible", "Ctrl+T");
-
-
-	settings.init("KeyBindings/Help-about", "F1");
-#ifdef UPDATER
-	settings.init("KeyBindings/Help-updates", "F12");
-#endif
-}
 
 MenuBar::MenuBar()
 {
@@ -466,108 +358,103 @@ MenuBar::Help::Help(MenuBar *parent) :
 
 void MenuBar::setKeyShourtcuts()
 {
-	Settings &settings = QMPlay2Core.getSettings();
+	ShortcutHandler* shortcuts = ShortcutHandler::instance();
+	shortcuts->appendAction(window->toggleVisibility, "KeyBindings/Window-toggleVisibility", "`");
+	shortcuts->appendAction(window->toggleFullScreen, "KeyBindings/Window-toggleFullScreen", "F");
+	shortcuts->appendAction(window->toggleCompactView, "KeyBindings/Window-toggleCompactView", "Alt+V");
+	shortcuts->appendAction(window->close, "KeyBindings/Window-close", "Alt+F4");
 
-	window->toggleVisibility->setShortcut(settings.getString("KeyBindings/Window-toggleVisibility"));
-	window->toggleFullScreen->setShortcut(settings.getString("KeyBindings/Window-toggleFullScreen"));
-	window->toggleCompactView->setShortcut(settings.getString("KeyBindings/Window-toggleCompactView"));
-	window->close->setShortcut(settings.getString("KeyBindings/Window-close"));
+	shortcuts->appendAction(playlist->stopLoading, "KeyBindings/Playlist-stopLoading", "F4");
+	shortcuts->appendAction(playlist->sync, "KeyBindings/Playlist-sync", "F5");
+	shortcuts->appendAction(playlist->loadPlist, "KeyBindings/Playlist-loadPlist", "Ctrl+L");
+	shortcuts->appendAction(playlist->savePlist, "KeyBindings/Playlist-savePlist", "Ctrl+S");
+	shortcuts->appendAction(playlist->saveGroup, "KeyBindings/Playlist-saveGroup", "Ctrl+Shift+S");
+	shortcuts->appendAction(playlist->delEntries, "KeyBindings/Playlist-delEntries", "Del");
+	shortcuts->appendAction(playlist->delNonGroupEntries, "KeyBindings/Playlist-delNonGroupEntries", "Ctrl+Del");
+	shortcuts->appendAction(playlist->clear, "KeyBindings/Playlist-clear", "Shift+Del");
+	shortcuts->appendAction(playlist->copy, "KeyBindings/Playlist-copy", "Ctrl+C");
+	shortcuts->appendAction(playlist->paste, "KeyBindings/Playlist-paste", "Ctrl+V");
+	shortcuts->appendAction(playlist->newGroup, "KeyBindings/Playlist-newGroup", "F7");
+	shortcuts->appendAction(playlist->renameGroup, "KeyBindings/Playlist-renameGroup", "F2");
+	shortcuts->appendAction(playlist->find, "KeyBindings/Playlist-find", "Ctrl+F");
+	shortcuts->appendAction(playlist->collapseAll, "KeyBindings/Playlist-collapseAll", "");
+	shortcuts->appendAction(playlist->expandAll, "KeyBindings/Playlist-expandAll", "");
+	shortcuts->appendAction(playlist->goToPlayback, "KeyBindings/Playlist-goToPlayback", "Ctrl+P");
+	shortcuts->appendAction(playlist->queue, "KeyBindings/Playlist-queue", "Q");
+	shortcuts->appendAction(playlist->entryProperties, "KeyBindings/Playlist-entryProperties", "Alt+Return");
 
+	shortcuts->appendAction(playlist->add->file, "KeyBindings/Playlist-Add-file", "Ctrl+I");
+	shortcuts->appendAction(playlist->add->dir, "KeyBindings/Playlist-Add-dir", "Ctrl+D");
+	shortcuts->appendAction(playlist->add->address, "KeyBindings/Playlist-Add-address", "Ctrl+U");
 
-	playlist->stopLoading->setShortcut(settings.getString("KeyBindings/Playlist-stopLoading"));
-	playlist->sync->setShortcut(settings.getString("KeyBindings/Playlist-sync"));
-	playlist->loadPlist->setShortcut(settings.getString("KeyBindings/Playlist-loadPlist"));
-	playlist->savePlist->setShortcut(settings.getString("KeyBindings/Playlist-savePlist"));
-	playlist->saveGroup->setShortcut(settings.getString("KeyBindings/Playlist-saveGroup"));
-	playlist->delEntries->setShortcut(settings.getString("KeyBindings/Playlist-delEntries"));
-	playlist->delNonGroupEntries->setShortcut(settings.getString("KeyBindings/Playlist-delNonGroupEntries"));
-	playlist->clear->setShortcut(settings.getString("KeyBindings/Playlist-clear"));
-	playlist->copy->setShortcut(settings.getString("KeyBindings/Playlist-copy"));
-	playlist->paste->setShortcut(settings.getString("KeyBindings/Playlist-paste"));
-	playlist->newGroup->setShortcut(settings.getString("KeyBindings/Playlist-newGroup"));
-	playlist->renameGroup->setShortcut(settings.getString("KeyBindings/Playlist-renameGroup"));
-	playlist->find->setShortcut(settings.getString("KeyBindings/Playlist-find"));
-	playlist->collapseAll->setShortcut(settings.getString("KeyBindings/Playlist-collapseAll"));
-	playlist->expandAll->setShortcut(settings.getString("KeyBindings/Playlist-expandAll"));
-	playlist->goToPlayback->setShortcut(settings.getString("KeyBindings/Playlist-goToPlayback"));
-	playlist->queue->setShortcut(settings.getString("KeyBindings/Playlist-queue"));
-	playlist->entryProperties->setShortcut(settings.getString("KeyBindings/Playlist-entryProperties"));
+	shortcuts->appendAction(playlist->sort->timeSort1, "KeyBindings/Playlist-Sort-timeSort1", "");
+	shortcuts->appendAction(playlist->sort->timeSort2, "KeyBindings/Playlist-Sort-timeSort2", "");
+	shortcuts->appendAction(playlist->sort->titleSort1, "KeyBindings/Playlist-Sort-titleSort1", "");
+	shortcuts->appendAction(playlist->sort->titleSort2, "KeyBindings/Playlist-Sort-titleSort2", "");
 
-	playlist->add->file->setShortcut(settings.getString("KeyBindings/Playlist-Add-file"));
-	playlist->add->dir->setShortcut(settings.getString("KeyBindings/Playlist-Add-dir"));
-	playlist->add->address->setShortcut(settings.getString("KeyBindings/Playlist-Add-address"));
+	shortcuts->appendAction(player->togglePlay, "KeyBindings/Player-togglePlay", "Space");
+	shortcuts->appendAction(player->stop, "KeyBindings/Player-stop", "V");
+	shortcuts->appendAction(player->next, "KeyBindings/Player-next", "B");
+	shortcuts->appendAction(player->prev, "KeyBindings/Player-prev", "Z");
+	shortcuts->appendAction(player->nextFrame, "KeyBindings/Player-nextFrame", ".");
+	shortcuts->appendAction(player->abRepeat, "KeyBindings/Player-abRepeat", "Ctrl+-");
+	shortcuts->appendAction(player->seekF, "KeyBindings/Player-seekF", "Right");
+	shortcuts->appendAction(player->seekB, "KeyBindings/Player-seekB", "Left");
+	shortcuts->appendAction(player->lSeekF, "KeyBindings/Player-lSeekF", "Up");
+	shortcuts->appendAction(player->lSeekB, "KeyBindings/Player-lSeekB", "Down");
+	shortcuts->appendAction(player->speedUp, "KeyBindings/Player-speedUp", "]");
+	shortcuts->appendAction(player->slowDown, "KeyBindings/Player-slowDown", "[");
+	shortcuts->appendAction(player->setSpeed, "KeyBindings/Player-setSpeed", "Shift+S");
+	shortcuts->appendAction(player->zoomIn, "KeyBindings/Player-zoomIn", "E");
+	shortcuts->appendAction(player->zoomOut, "KeyBindings/Player-zoomOut", "W");
+	shortcuts->appendAction(player->switchARatio, "KeyBindings/Player-switchARatio", "A");
+	shortcuts->appendAction(player->reset, "KeyBindings/Player-reset", "R");
+	shortcuts->appendAction(player->volUp, "KeyBindings/Player-volUp", "*");
+	shortcuts->appendAction(player->volDown, "KeyBindings/Player-volDown", "/");
+	shortcuts->appendAction(player->toggleMute, "KeyBindings/Player-toggleMute", "M");
+	if(player->detach)
+		shortcuts->appendAction(player->detach, "KeyBindings/Player-detach", "");
+	if(player->suspend)
+		shortcuts->appendAction(player->suspend, "KeyBindings/Player-suspend", "");
 
-	playlist->sort->timeSort1->setShortcut(settings.getString("KeyBindings/Playlist-Sort-timeSort1"));
-	playlist->sort->timeSort2->setShortcut(settings.getString("KeyBindings/Playlist-Sort-timeSort2"));
-	playlist->sort->titleSort1->setShortcut(settings.getString("KeyBindings/Playlist-Sort-titleSort1"));
-	playlist->sort->titleSort2->setShortcut(settings.getString("KeyBindings/Playlist-Sort-titleSort2"));
-
-
-	player->togglePlay->setShortcut(settings.getString("KeyBindings/Player-togglePlay"));
-	player->stop->setShortcut(settings.getString("KeyBindings/Player-stop"));
-	player->next->setShortcut(settings.getString("KeyBindings/Player-next"));
-	player->prev->setShortcut(settings.getString("KeyBindings/Player-prev"));
-	player->nextFrame->setShortcut(settings.getString("KeyBindings/Player-nextFrame"));
-	player->abRepeat->setShortcut(settings.getString("KeyBindings/Player-abRepeat"));
-	player->seekF->setShortcut(settings.getString("KeyBindings/Player-seekF"));
-	player->seekB->setShortcut(settings.getString("KeyBindings/Player-seekB"));
-	player->lSeekF->setShortcut(settings.getString("KeyBindings/Player-lSeekF"));
-	player->lSeekB->setShortcut(settings.getString("KeyBindings/Player-lSeekB"));
-	player->speedUp->setShortcut(settings.getString("KeyBindings/Player-speedUp"));
-	player->slowDown->setShortcut(settings.getString("KeyBindings/Player-slowDown"));
-	player->setSpeed->setShortcut(settings.getString("KeyBindings/Player-setSpeed"));
-	player->zoomIn->setShortcut(settings.getString("KeyBindings/Player-zoomIn"));
-	player->zoomOut->setShortcut(settings.getString("KeyBindings/Player-zoomOut"));
-	player->switchARatio->setShortcut(settings.getString("KeyBindings/Player-switchARatio"));
-	player->reset->setShortcut(settings.getString("KeyBindings/Player-reset"));
-	player->volUp->setShortcut(settings.getString("KeyBindings/Player-volUp"));
-	player->volDown->setShortcut(settings.getString("KeyBindings/Player-volDown"));
-	player->toggleMute->setShortcut(settings.getString("KeyBindings/Player-toggleMute"));
-	if (player->detach)
-		player->detach->setShortcut(settings.getString("KeyBindings/Player-detach"));
-	if (player->suspend)
-		player->suspend->setShortcut(settings.getString("KeyBindings/Player-suspend"));
-
-	player->repeat->repeatActions[RepeatNormal]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RepeatNormal"));
-	player->repeat->repeatActions[RepeatEntry]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RepeatEntry"));
-	player->repeat->repeatActions[RepeatGroup]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RepeatGroup"));
-	player->repeat->repeatActions[RepeatList]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RepeatList"));
-	player->repeat->repeatActions[RandomMode]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RandomMode"));
-	player->repeat->repeatActions[RandomGroupMode]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RandomGroupMode"));
-	player->repeat->repeatActions[RepeatRandom]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RepeatRandom"));
-	player->repeat->repeatActions[RepeatRandomGroup]->setShortcut(settings.getString("KeyBindings/Player-Repeat-RepeatRandomGroup"));
+	shortcuts->appendAction(player->repeat->repeatActions[RepeatNormal], "KeyBindings/Player-Repeat-RepeatNormal", "Alt+0");
+	shortcuts->appendAction(player->repeat->repeatActions[RepeatEntry], "KeyBindings/Player-Repeat-RepeatEntry", "Alt+1");
+	shortcuts->appendAction(player->repeat->repeatActions[RepeatGroup], "KeyBindings/Player-Repeat-RepeatGroup", "Alt+2");
+	shortcuts->appendAction(player->repeat->repeatActions[RepeatList], "KeyBindings/Player-Repeat-RepeatList", "Alt+3");
+	shortcuts->appendAction(player->repeat->repeatActions[RandomMode], "KeyBindings/Player-Repeat-RandomMode", "Alt+4");
+	shortcuts->appendAction(player->repeat->repeatActions[RandomGroupMode], "KeyBindings/Player-Repeat-RandomGroupMode", "Alt+5");
+	shortcuts->appendAction(player->repeat->repeatActions[RepeatRandom], "KeyBindings/Player-Repeat-RepeatRandom", "Alt+6");
+	shortcuts->appendAction(player->repeat->repeatActions[RepeatRandomGroup], "KeyBindings/Player-Repeat-RepeatRandomGroup", "Alt+7");
 
 
-	playback->toggleAudio->setShortcut(settings.getString("KeyBindings/Playback-toggleAudio"));
-	playback->toggleVideo->setShortcut(settings.getString("KeyBindings/Playback-toggleVideo"));
-	playback->videoSync->setShortcut(settings.getString("KeyBindings/Playback-videoSync"));
-	playback->slowDownVideo->setShortcut(settings.getString("KeyBindings/Playback-slowDownVideo"));
-	playback->speedUpVideo->setShortcut(settings.getString("KeyBindings/Playback-speedUpVideo"));
-	playback->toggleSubtitles->setShortcut(settings.getString("KeyBindings/Playback-toggleSubtitles"));
-	playback->subsFromFile->setShortcut(settings.getString("KeyBindings/Playback-subsFromFile"));
-	playback->subtitlesSync->setShortcut(settings.getString("KeyBindings/Playback-subtitlesSync"));
-	playback->slowDownSubtitles->setShortcut(settings.getString("KeyBindings/Playback-slowDownSubtitles"));
-	playback->speedUpSubtitles->setShortcut(settings.getString("KeyBindings/Playback-speedUpSubtitles"));
-	playback->biggerSubtitles->setShortcut(settings.getString("KeyBindings/Playback-biggerSubtitles"));
-	playback->smallerSubtitles->setShortcut(settings.getString("KeyBindings/Playback-smallerSubtitles"));
-	playback->playbackSettings->setShortcut(settings.getString("KeyBindings/Playback-playbackSettings"));
-	playback->screenShot->setShortcut(settings.getString("KeyBindings/Playback-screenShot"));
+	shortcuts->appendAction(playback->toggleAudio, "KeyBindings/Playback-toggleAudio", "D");
+	shortcuts->appendAction(playback->toggleVideo, "KeyBindings/Playback-toggleVideo", "O");
+	shortcuts->appendAction(playback->videoSync, "KeyBindings/Playback-videoSync", "Shift+O");
+	shortcuts->appendAction(playback->slowDownVideo, "KeyBindings/Playback-slowDownVideo", "-");
+	shortcuts->appendAction(playback->speedUpVideo, "KeyBindings/Playback-speedUpVideo", "+");
+	shortcuts->appendAction(playback->toggleSubtitles, "KeyBindings/Playback-toggleSubtitles", "N");
+	shortcuts->appendAction(playback->subsFromFile, "KeyBindings/Playback-subsFromFile", "Alt+I");
+	shortcuts->appendAction(playback->subtitlesSync, "KeyBindings/Playback-subtitlesSync", "Shift+N");
+	shortcuts->appendAction(playback->slowDownSubtitles, "KeyBindings/Playback-slowDownSubtitles", "Shift+Z");
+	shortcuts->appendAction(playback->speedUpSubtitles, "KeyBindings/Playback-speedUpSubtitles", "Shift+X");
+	shortcuts->appendAction(playback->biggerSubtitles, "KeyBindings/Playback-biggerSubtitles", "Shift+R");
+	shortcuts->appendAction(playback->smallerSubtitles, "KeyBindings/Playback-smallerSubtitles", "Shift+T");
+	shortcuts->appendAction(playback->playbackSettings, "KeyBindings/Playback-playbackSettings", "Ctrl+Shift+P");
+	shortcuts->appendAction(playback->screenShot, "KeyBindings/Playback-screenShot", "Alt+S");
 
-	playback->videoFilters->spherical->setShortcut(settings.getString("KeyBindings/Playback-VideoFilters-spherical"));
-	playback->videoFilters->hFlip->setShortcut(settings.getString("KeyBindings/Playback-VideoFilters-hFlip"));
-	playback->videoFilters->vFlip->setShortcut(settings.getString("KeyBindings/Playback-VideoFilters-vFlip"));
-	playback->videoFilters->rotate90->setShortcut(settings.getString("KeyBindings/Playback-VideoFilters-rotate90"));
-	playback->videoFilters->more->setShortcut(settings.getString("KeyBindings/Playback-VideoFilters-more"));
+	shortcuts->appendAction(playback->videoFilters->spherical, "KeyBindings/Playback-VideoFilters-spherical", "Ctrl+3");
+	shortcuts->appendAction(playback->videoFilters->hFlip, "KeyBindings/Playback-VideoFilters-hFlip", "Ctrl+M");
+	shortcuts->appendAction(playback->videoFilters->vFlip, "KeyBindings/Playback-VideoFilters-vFlip", "Ctrl+R");
+	shortcuts->appendAction(playback->videoFilters->rotate90, "KeyBindings/Playback-VideoFilters-rotate90", "Ctrl+9");
+	shortcuts->appendAction(playback->videoFilters->more, "KeyBindings/Playback-VideoFilters-more", "Alt+F");
 
+	shortcuts->appendAction(options->settings, "KeyBindings/Options-settings", "Ctrl+O");
+	shortcuts->appendAction(options->modulesSettings, "KeyBindings/Options-modulesSettings", "Ctrl+Shift+O");
+	shortcuts->appendAction(options->trayVisible, "KeyBindings/Options-trayVisible", "Ctrl+T");
 
-	options->settings->setShortcut(settings.getString("KeyBindings/Options-settings"));
-	options->modulesSettings->setShortcut(settings.getString("KeyBindings/Options-modulesSettings"));
-	options->trayVisible->setShortcut(settings.getString("KeyBindings/Options-trayVisible"));
-
-
-	help->about->setShortcut(settings.getString("KeyBindings/Help-about"));
+	shortcuts->appendAction(help->about, "KeyBindings/Help-about", "F1");
 #ifdef UPDATER
-	help->updates->setShortcut(settings.getString("KeyBindings/Help-updates"));
+	shortcuts->appendAction(help->updates, "KeyBindings/Help-updates", "F12");
 #endif
 }
 

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -358,7 +358,7 @@ MenuBar::Help::Help(MenuBar *parent) :
 
 void MenuBar::setKeyShourtcuts()
 {
-	ShortcutHandler* shortcuts = ShortcutHandler::instance();
+	ShortcutHandler *shortcuts = ShortcutHandler::instance();
 	shortcuts->appendAction(window->toggleVisibility, "KeyBindings/Window-toggleVisibility", "`");
 	shortcuts->appendAction(window->toggleFullScreen, "KeyBindings/Window-toggleFullScreen", "F");
 	shortcuts->appendAction(window->toggleCompactView, "KeyBindings/Window-toggleCompactView", "Alt+V");
@@ -412,9 +412,9 @@ void MenuBar::setKeyShourtcuts()
 	shortcuts->appendAction(player->volUp, "KeyBindings/Player-volUp", "*");
 	shortcuts->appendAction(player->volDown, "KeyBindings/Player-volDown", "/");
 	shortcuts->appendAction(player->toggleMute, "KeyBindings/Player-toggleMute", "M");
-	if(player->detach)
+	if (player->detach)
 		shortcuts->appendAction(player->detach, "KeyBindings/Player-detach", "");
-	if(player->suspend)
+	if (player->suspend)
 		shortcuts->appendAction(player->suspend, "KeyBindings/Player-suspend", "");
 
 	shortcuts->appendAction(player->repeat->repeatActions[RepeatNormal], "KeyBindings/Player-Repeat-RepeatNormal", "Alt+0");

--- a/src/gui/MenuBar.hpp
+++ b/src/gui/MenuBar.hpp
@@ -28,8 +28,6 @@ class MenuBar : public QMenuBar
 {
 	Q_OBJECT
 public:
-	static void init();
-
 	MenuBar();
 
 	class Window : public QMenu

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -571,7 +571,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 
 	/* Page 7 */
 	{
-		shortcuts = new QTableView(this);
+		QTableView *shortcuts = new QTableView(this);
 		shortcuts->setModel(ShortcutHandler::instance());
 		shortcuts->setFrameShape(QFrame::NoFrame);
 		shortcuts->setAlternatingRowColors(true);

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -22,6 +22,7 @@
 #include <OtherVFiltersW.hpp>
 #include <OSDSettingsW.hpp>
 #include <Main.hpp>
+#include <ShortcutHandler.hpp>
 
 #if QT_VERSION < 0x050000
 	#include <QDesktopServices>
@@ -50,6 +51,7 @@
 #include <QSpinBox>
 #include <QLabel>
 #include <QDir>
+#include <QTableView>
 
 #include <Appearance.hpp>
 #include <Settings.hpp>
@@ -202,7 +204,6 @@ void SettingsWidget::InitSettings()
 	OSDSettingsW::init("Subtitles", 20, 0, 15, 15, 15, 7, 1.5, 1.5, QColor(0xFF, 0xA8, 0x58, 0xFF), Qt::black, Qt::black);
 	OSDSettingsW::init("OSD",       32, 0, 0,  0,  0,  4, 1.5, 1.5, QColor(0xAA, 0xFF, 0x55, 0xFF), Qt::black, Qt::black);
 	DeintSettingsW::init();
-	MenuBar::init();
 	applyProxy();
 }
 void SettingsWidget::SetAudioChannelsMenu()
@@ -568,6 +569,23 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 		page6->setWidget(widget);
 	}
 
+	/* Page 7 */
+	{
+		shortcuts = new QTableView(this);
+		shortcuts->setModel(ShortcutHandler::instance());
+		shortcuts->setFrameShape(QFrame::NoFrame);
+		shortcuts->setAlternatingRowColors(true);
+#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
+		shortcuts->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+		shortcuts->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+#else
+		shortcuts->horizontalHeader()->setResizeMode(0, QHeaderView::ResizeToContents);
+		shortcuts->horizontalHeader()->setResizeMode(1, QHeaderView::Stretch);
+#endif
+		shortcuts->verticalHeader()->setVisible(false);
+		tabW->addTab(shortcuts, tr("Shortcuts"));
+	}
+
 	connect(tabW, SIGNAL(currentChanged(int)), this, SLOT(tabCh(int)));
 	tabW->setCurrentIndex(page);
 
@@ -672,6 +690,7 @@ void SettingsWidget::chStyle()
 		QMPlay2GUI.setStyle();
 	}
 }
+
 void SettingsWidget::apply()
 {
 	Settings &QMPSettings = QMPlay2Core.getSettings();
@@ -803,6 +822,9 @@ void SettingsWidget::apply()
 			page6->deintSettingsW->writeSettings();
 			if (page6->otherVFiltersW)
 				page6->otherVFiltersW->writeSettings();
+			break;
+		case 7:
+			ShortcutHandler::instance()->submit();
 			break;
 	}
 	if (page != 3)

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -22,7 +22,6 @@
 #include <OtherVFiltersW.hpp>
 #include <OSDSettingsW.hpp>
 #include <Main.hpp>
-#include <ShortcutHandler.hpp>
 
 #if QT_VERSION < 0x050000
 	#include <QDesktopServices>
@@ -51,9 +50,9 @@
 #include <QSpinBox>
 #include <QLabel>
 #include <QDir>
-#include <QTableView>
 
 #include <Appearance.hpp>
+#include <KeyBindingsDialog.hpp>
 #include <Settings.hpp>
 #include <MenuBar.hpp>
 #include <Module.hpp>
@@ -318,6 +317,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 		connect(page1->screenshotB, SIGNAL(clicked()), this, SLOT(chooseScreenshotDir()));
 
 		connect(page1->setAppearanceB, SIGNAL(clicked()), this, SLOT(setAppearance()));
+		connect(page1->setKeyBindingsB, SIGNAL(clicked()), this, SLOT(setKeyBindings()));
 
 #ifdef ICONS_FROM_THEME
 		page1->iconsFromTheme->setChecked(QMPSettings.getBool("IconsFromTheme"));
@@ -569,23 +569,6 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 		page6->setWidget(widget);
 	}
 
-	/* Page 7 */
-	{
-		QTableView *shortcuts = new QTableView(this);
-		shortcuts->setModel(ShortcutHandler::instance());
-		shortcuts->setFrameShape(QFrame::NoFrame);
-		shortcuts->setAlternatingRowColors(true);
-#if QT_VERSION >= QT_VERSION_CHECK(5,0,0)
-		shortcuts->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-		shortcuts->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
-#else
-		shortcuts->horizontalHeader()->setResizeMode(0, QHeaderView::ResizeToContents);
-		shortcuts->horizontalHeader()->setResizeMode(1, QHeaderView::Stretch);
-#endif
-		shortcuts->verticalHeader()->setVisible(false);
-		tabW->addTab(shortcuts, tr("Shortcuts"));
-	}
-
 	connect(tabW, SIGNAL(currentChanged(int)), this, SLOT(tabCh(int)));
 	tabW->setCurrentIndex(page);
 
@@ -823,9 +806,6 @@ void SettingsWidget::apply()
 			if (page6->otherVFiltersW)
 				page6->otherVFiltersW->writeSettings();
 			break;
-		case 7:
-			ShortcutHandler::instance()->submit();
-			break;
 	}
 	if (page != 3)
 		QMPSettings.flush();
@@ -951,6 +931,12 @@ void SettingsWidget::setAppearance()
 {
 	Appearance(this).exec();
 }
+
+void SettingsWidget::setKeyBindings()
+{
+	KeyBindingsDialog(this).exec();
+}
+
 void SettingsWidget::clearCoversCache()
 {
 	if (QMessageBox::question(this, tr("Confirm clearing the cache covers"), tr("Do you want to delete all cached covers?"), QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -82,6 +82,7 @@ private slots:
 	void moveModule();
 	void chooseScreenshotDir();
 	void setAppearance();
+	void setKeyBindings();
 	void clearCoversCache();
 	void resetSettings();
 signals:

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -29,7 +29,6 @@ class Page3;
 class Page4;
 class Page5;
 class Page6;
-class QTableView;
 
 namespace Ui {
 	class GeneralSettings;
@@ -66,7 +65,6 @@ private:
 	Page4 *page4;
 	Page5 *page5;
 	Page6 *page6;
-	QTableView *shortcuts;
 
 	QTabWidget *tabW;
 	QString lastM[3];

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -29,6 +29,7 @@ class Page3;
 class Page4;
 class Page5;
 class Page6;
+class QTableView;
 
 namespace Ui {
 	class GeneralSettings;
@@ -65,6 +66,7 @@ private:
 	Page4 *page4;
 	Page5 *page5;
 	Page6 *page6;
+	QTableView *shortcuts;
 
 	QTabWidget *tabW;
 	QString lastM[3];

--- a/src/gui/ShortcutHandler.cpp
+++ b/src/gui/ShortcutHandler.cpp
@@ -97,7 +97,7 @@ QVariant ShortcutHandler::data(const QModelIndex &index, int role) const
 		switch (index.column())
 		{
 			case 0:
-				return action->text().remove(QLatin1Char('&'));
+				return action->text().remove('&');
 			case 1:
 				return m_shortcuts.value(action);
 		}

--- a/src/gui/ShortcutHandler.cpp
+++ b/src/gui/ShortcutHandler.cpp
@@ -22,23 +22,21 @@
 
 #include <QApplication>
 
-ShortcutHandler *ShortcutHandler::s_instance = Q_NULLPTR;
+ShortcutHandler *ShortcutHandler::s_instance = NULL;
 
 ShortcutHandler *ShortcutHandler::instance()
 {
-	if (s_instance == Q_NULLPTR)
+	if (s_instance == NULL)
 		s_instance = new ShortcutHandler;
 	return s_instance;
 }
 
 ShortcutHandler::ShortcutHandler() :
 	settings(QMPlay2Core.getSettings())
-{
-}
+{}
 
 ShortcutHandler::~ShortcutHandler()
-{
-}
+{}
 
 void ShortcutHandler::appendAction(QAction *action, const QString &settingsName, const QString &default_shortcut)
 {
@@ -65,7 +63,7 @@ int ShortcutHandler::rowCount(const QModelIndex &parent) const
 
 Qt::ItemFlags ShortcutHandler::flags(const QModelIndex &index) const
 {
-	switch(index.column())
+	switch (index.column())
 	{
 		case 0:
 			return Qt::ItemIsEnabled;
@@ -78,9 +76,9 @@ Qt::ItemFlags ShortcutHandler::flags(const QModelIndex &index) const
 QVariant ShortcutHandler::headerData(int section, Qt::Orientation orientation, int role) const
 {
 	Q_UNUSED(orientation);
-	if(role == Qt::DisplayRole)
+	if (role == Qt::DisplayRole)
 	{
-		switch(section)
+		switch (section)
 		{
 			case 0:
 				return tr("Action");
@@ -93,10 +91,10 @@ QVariant ShortcutHandler::headerData(int section, Qt::Orientation orientation, i
 
 QVariant ShortcutHandler::data(const QModelIndex &index, int role) const
 {
-	if((role == Qt::DisplayRole || role == Qt::EditRole) && index.row() >= 0 && index.row() < m_actions.count())
+	if ((role == Qt::DisplayRole || role == Qt::EditRole) && index.row() >= 0 && index.row() < m_actions.count())
 	{
 		QAction *action = m_actions.at(index.row());
-		switch(index.column())
+		switch (index.column())
 		{
 			case 0:
 				return action->text().remove(QLatin1Char('&'));
@@ -109,7 +107,7 @@ QVariant ShortcutHandler::data(const QModelIndex &index, int role) const
 
 bool ShortcutHandler::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-	if(role == Qt::EditRole && index.column() == 1 && index.row() >= 0 && index.row() < m_actions.count())
+	if (role == Qt::EditRole && index.column() == 1 && index.row() >= 0 && index.row() < m_actions.count())
 	{
 		m_shortcuts.insert(m_actions.at(index.row()), value.toString());
 		emit dataChanged(index, index);
@@ -118,32 +116,31 @@ bool ShortcutHandler::setData(const QModelIndex &index, const QVariant &value, i
 	return false;
 }
 
-bool ShortcutHandler::submit()
+void ShortcutHandler::save()
 {
-	for (Shortcuts::iterator iterator = m_shortcuts.begin(); iterator != m_shortcuts.end(); ++iterator)
+	for (Shortcuts::const_iterator iterator = m_shortcuts.constBegin(); iterator != m_shortcuts.constEnd(); ++iterator)
 	{
-		iterator.key()->setShortcut(iterator.value());
+		iterator.key()->setShortcut(iterator.value().trimmed());
 		settings.set(iterator.key()->property("settingsId").toString(), iterator.value());
 	}
-	return true;
 }
 
-void ShortcutHandler::revert()
+void ShortcutHandler::restore()
 {
-	// TODO: need testing - might not work
 	for (Shortcuts::iterator iterator = m_shortcuts.begin(); iterator != m_shortcuts.end(); ++iterator)
 	{
-		m_shortcuts.insert(iterator.key(), iterator.key()->shortcut().toString());
+		iterator.value() = iterator.key()->shortcut().toString();
 	}
 	emit dataChanged(createIndex(0, 1), createIndex(m_actions.count(), 1));
 }
 
 void ShortcutHandler::reset()
 {
-	// TODO: need testing - might not work
-	for (Shortcuts::iterator iterator = m_defaultShortcuts.begin(); iterator != m_defaultShortcuts.end(); ++iterator)
+	for (Shortcuts::const_iterator iterator = m_defaultShortcuts.constBegin(); iterator != m_defaultShortcuts.constEnd(); ++iterator)
 	{
 		m_shortcuts.insert(iterator.key(), iterator.value());
+		iterator.key()->setShortcut(iterator.value().trimmed());
+		settings.set(iterator.key()->property("settingsId").toString(), iterator.value());
 	}
 	emit dataChanged(createIndex(0, 1), createIndex(m_actions.count(), 1));
 }

--- a/src/gui/ShortcutHandler.cpp
+++ b/src/gui/ShortcutHandler.cpp
@@ -1,0 +1,149 @@
+/*
+	QMPlay2 is a video and audio player.
+	Copyright (C) 2010-2016  Błażej Szczygieł
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <ShortcutHandler.hpp>
+#include <QMPlay2Core.hpp>
+#include <Settings.hpp>
+
+#include <QApplication>
+
+ShortcutHandler *ShortcutHandler::s_instance = Q_NULLPTR;
+
+ShortcutHandler *ShortcutHandler::instance()
+{
+	if (s_instance == Q_NULLPTR)
+		s_instance = new ShortcutHandler;
+	return s_instance;
+}
+
+ShortcutHandler::ShortcutHandler() :
+	settings(QMPlay2Core.getSettings())
+{
+}
+
+ShortcutHandler::~ShortcutHandler()
+{
+}
+
+void ShortcutHandler::appendAction(QAction *action, const QString &settingsName, const QString &default_shortcut)
+{
+	QString shortcut = settings.getString(settingsName, default_shortcut);
+	action->setShortcut(shortcut);
+	action->setProperty("settingsId", settingsName);
+
+	m_actions.append(action);
+	m_shortcuts.insert(action, shortcut);
+	m_defaultShortcuts.insert(action, default_shortcut);
+}
+
+int ShortcutHandler::columnCount(const QModelIndex &parent) const
+{
+	Q_UNUSED(parent);
+	return 2;
+}
+
+int ShortcutHandler::rowCount(const QModelIndex &parent) const
+{
+	Q_UNUSED(parent);
+	return m_actions.count();
+}
+
+Qt::ItemFlags ShortcutHandler::flags(const QModelIndex &index) const
+{
+	switch(index.column())
+	{
+		case 0:
+			return Qt::ItemIsEnabled;
+		case 1:
+			return Qt::ItemIsEnabled | Qt::ItemIsEditable;
+	}
+	return Qt::NoItemFlags;
+}
+
+QVariant ShortcutHandler::headerData(int section, Qt::Orientation orientation, int role) const
+{
+	Q_UNUSED(orientation);
+	if(role == Qt::DisplayRole)
+	{
+		switch(section)
+		{
+			case 0:
+				return tr("Action");
+			case 1:
+				return tr("Key sequence");
+		}
+	}
+	return QVariant();
+}
+
+QVariant ShortcutHandler::data(const QModelIndex &index, int role) const
+{
+	if((role == Qt::DisplayRole || role == Qt::EditRole) && index.row() >= 0 && index.row() < m_actions.count())
+	{
+		QAction *action = m_actions.at(index.row());
+		switch(index.column())
+		{
+			case 0:
+				return action->text().remove(QLatin1Char('&'));
+			case 1:
+				return m_shortcuts.value(action);
+		}
+	}
+	return QVariant();
+}
+
+bool ShortcutHandler::setData(const QModelIndex &index, const QVariant &value, int role)
+{
+	if(role == Qt::EditRole && index.column() == 1 && index.row() >= 0 && index.row() < m_actions.count())
+	{
+		m_shortcuts.insert(m_actions.at(index.row()), value.toString());
+		emit dataChanged(index, index);
+		return true;
+	}
+	return false;
+}
+
+bool ShortcutHandler::submit()
+{
+	for (Shortcuts::iterator iterator = m_shortcuts.begin(); iterator != m_shortcuts.end(); ++iterator)
+	{
+		iterator.key()->setShortcut(iterator.value());
+		settings.set(iterator.key()->property("settingsId").toString(), iterator.value());
+	}
+	return true;
+}
+
+void ShortcutHandler::revert()
+{
+	// TODO: need testing - might not work
+	for (Shortcuts::iterator iterator = m_shortcuts.begin(); iterator != m_shortcuts.end(); ++iterator)
+	{
+		m_shortcuts.insert(iterator.key(), iterator.key()->shortcut().toString());
+	}
+	emit dataChanged(createIndex(0, 1), createIndex(m_actions.count(), 1));
+}
+
+void ShortcutHandler::reset()
+{
+	// TODO: need testing - might not work
+	for (Shortcuts::iterator iterator = m_defaultShortcuts.begin(); iterator != m_defaultShortcuts.end(); ++iterator)
+	{
+		m_shortcuts.insert(iterator.key(), iterator.value());
+	}
+	emit dataChanged(createIndex(0, 1), createIndex(m_actions.count(), 1));
+}

--- a/src/gui/ShortcutHandler.hpp
+++ b/src/gui/ShortcutHandler.hpp
@@ -46,8 +46,8 @@ public:
 	void appendAction(QAction *action, const QString &settingsName, const QString &default_shortcut);
 
 public slots:
-	bool submit();
-	void revert();
+	void save();
+	void restore();
 
 	void reset();
 
@@ -58,9 +58,9 @@ private:
 	ShortcutHandler();
 
 	Settings &settings;
-	QList<QAction*> m_actions;
+	QList<QAction *> m_actions;
 
-	typedef QHash<QAction*, QString> Shortcuts;
+	typedef QHash<QAction *, QString> Shortcuts;
 	Shortcuts m_shortcuts;
 	Shortcuts m_defaultShortcuts;
 

--- a/src/gui/ShortcutHandler.hpp
+++ b/src/gui/ShortcutHandler.hpp
@@ -1,0 +1,69 @@
+/*
+	QMPlay2 is a video and audio player.
+	Copyright (C) 2010-2016  Błażej Szczygieł
+
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Lesser General Public License as published
+	by the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU Lesser General Public License for more details.
+
+	You should have received a copy of the GNU Lesser General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SHORTCUTHANDLER_H
+#define SHORTCUTHANDLER_H
+
+#include <QAbstractTableModel>
+#include <QAction>
+#include <QKeySequence>
+
+class QSettings;
+class Settings;
+
+class ShortcutHandler : public QAbstractTableModel
+{
+	Q_OBJECT
+public:
+	static ShortcutHandler *instance();
+	~ShortcutHandler();
+
+	int columnCount(const QModelIndex &parent) const;
+	int rowCount(const QModelIndex &parent) const;
+
+	Qt::ItemFlags flags(const QModelIndex &index) const;
+
+	QVariant headerData(int section, Qt::Orientation orientation, int role) const;
+
+	QVariant data(const QModelIndex &index, int role) const;
+	bool setData(const QModelIndex &index, const QVariant &value, int role);
+
+	void appendAction(QAction *action, const QString &settingsName, const QString &default_shortcut);
+
+public slots:
+	bool submit();
+	void revert();
+
+	void reset();
+
+private:
+	Q_DISABLE_COPY(ShortcutHandler)
+
+	static ShortcutHandler *s_instance;
+	ShortcutHandler();
+
+	Settings &settings;
+	QList<QAction*> m_actions;
+
+	typedef QHash<QAction*, QString> Shortcuts;
+	Shortcuts m_shortcuts;
+	Shortcuts m_defaultShortcuts;
+
+};
+
+#endif // SHORTCUTHANDLER_H

--- a/src/gui/Ui/SettingsGeneral.ui
+++ b/src/gui/Ui/SettingsGeneral.ui
@@ -190,6 +190,13 @@
            </property>
           </widget>
          </item>
+         <item row="7" column="0" colspan="2">
+          <widget class="QPushButton" name="setKeyBindingsB">
+           <property name="text">
+            <string>Set key bindings</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="2" column="0">

--- a/src/gui/gui.pro
+++ b/src/gui/gui.pro
@@ -30,8 +30,8 @@ UI_DIR = build/ui
 INCLUDEPATH += . ../qmplay2/headers
 DEPENDPATH  += . ../qmplay2/headers
 
-HEADERS += Main.hpp MenuBar.hpp MainWidget.hpp AddressBox.hpp VideoDock.hpp InfoDock.hpp PlaylistDock.hpp PlayClass.hpp DemuxerThr.hpp AVThread.hpp VideoThr.hpp AudioThr.hpp SettingsWidget.hpp OSDSettingsW.hpp DeintSettingsW.hpp OtherVFiltersW.hpp PlaylistWidget.hpp EntryProperties.hpp AboutWidget.hpp AddressDialog.hpp VideoAdjustment.hpp Appearance.hpp VolWidget.hpp RepeatMode.hpp ScreenSaver.hpp
-SOURCES += Main.cpp MenuBar.cpp MainWidget.cpp AddressBox.cpp VideoDock.cpp InfoDock.cpp PlaylistDock.cpp PlayClass.cpp DemuxerThr.cpp AVThread.cpp VideoThr.cpp AudioThr.cpp SettingsWidget.cpp OSDSettingsW.cpp DeintSettingsW.cpp OtherVFiltersW.cpp PlaylistWidget.cpp EntryProperties.cpp AboutWidget.cpp AddressDialog.cpp VideoAdjustment.cpp Appearance.cpp VolWidget.cpp ScreenSaver.cpp
+HEADERS += Main.hpp MenuBar.hpp MainWidget.hpp AddressBox.hpp VideoDock.hpp InfoDock.hpp PlaylistDock.hpp PlayClass.hpp DemuxerThr.hpp AVThread.hpp VideoThr.hpp AudioThr.hpp SettingsWidget.hpp OSDSettingsW.hpp DeintSettingsW.hpp OtherVFiltersW.hpp PlaylistWidget.hpp EntryProperties.hpp AboutWidget.hpp AddressDialog.hpp VideoAdjustment.hpp Appearance.hpp VolWidget.hpp RepeatMode.hpp ScreenSaver.hpp ShortcutHandler.hpp KeyBindingsDialog.hpp
+SOURCES += Main.cpp MenuBar.cpp MainWidget.cpp AddressBox.cpp VideoDock.cpp InfoDock.cpp PlaylistDock.cpp PlayClass.cpp DemuxerThr.cpp AVThread.cpp VideoThr.cpp AudioThr.cpp SettingsWidget.cpp OSDSettingsW.cpp DeintSettingsW.cpp OtherVFiltersW.cpp PlaylistWidget.cpp EntryProperties.cpp AboutWidget.cpp AddressDialog.cpp VideoAdjustment.cpp Appearance.cpp VolWidget.cpp ScreenSaver.cpp ShortcutHandler.cpp KeyBindingsDialog.cpp
 FORMS += Ui/SettingsGeneral.ui Ui/SettingsPlayback.ui Ui/SettingsPlaybackModulesList.ui Ui/OSDSettings.ui
 
 !android {


### PR DESCRIPTION
Well, after adding shortcuts changing using the config file, I thought to add UI for this.
I changed some approaches in shortcuts in MenuBar:

- added a new class `ShortcutHandler` (I hope this name is ok? )
- instead of setting default shortcuts in `MenuBar::init`, and then setting the shortcut for a Action, I moved all of this into `ShortcutHandler::appendAction` and there it is selected.
- I added simple `QTableView` with `ShortcutHandler` as it's model. This `QTableView` is the page7 widget.

I might have some problems with code style (as I added new code and not just replacing as for before). Please review it.

Also, I might have missed some actions, therefore I'm asking you to report the missing actions.

Some future insight:
I added `ShortcutHandler::revert()` and `ShortcutHandler::reset()` for future code of reverting the changes and returning to defaults. I didn't test it (therefore I added the TODO comment) but is should work properly.