### PR TITLE
Typos fix & Settings convert usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ QMPlay2 is a video and audio player. It can play all formats supported by FFmpeg
 Table of Contents
 =================
 
-* [Instalation](#instalation)
+* [Installation](#installation)
 * [YouTube](#youtube)
 * [Spherical view](#spherical-view)
 * [ALSA](#alsa)
@@ -16,11 +16,11 @@ Table of Contents
 * [Hardware acceleration](#hardware-acceleration)
 * [Deinterlacing](#deinterlacing)
 * [Hidden features](#hidden-features)
-* [Instalation from sources](#instalation-from-sources)
+* [Installation from sources](#installation-from-sources)
 * [Building package RPM, DEB or any other](#building-package-rpm-deb-or-any-other)
 * [Other information](#other-information)
 
-##Instalation
+##Installation
 
 ####Easy installation on Windows (XP or higher)
 
@@ -135,7 +135,7 @@ Right click on volume slider and select "Split channels".
 
 Go to "Options->Modules settings" and click "Extensions" on the list. Find "LastFM" group box, select "Scrobble", type your login and password and then press "Apply".
 
-##Instalation from sources
+##Installation from sources
 
 ###CMake requirements
 
@@ -259,9 +259,9 @@ For Qt4 build install also `qt4` package.
 
 CMake options (option - default value: description):
 - CMake options and the default settings:
-	- `CMAKE_INSTALL_PREFIX` - mostly it is `/usr/local`: instalation directory.
+	- `CMAKE_INSTALL_PREFIX` - mostly it is `/usr/local`: installation directory.
 	- `CMAKE_BUILD_TYPE` - `Release`.
-	- `LANGUAGES` - `All` - a space-seperated list of translations to compile into QMPlay2.
+	- `LANGUAGES` - `All` - a space-separated list of translations to compile into QMPlay2.
 	- `SOLID_ACTIONS_INSTALL_PATH` - Linux/BSD only, autodetect: you can specify the path manually.
 	- `SET_INSTALL_RPATH` - non-Windows only, `ON` on OS X, `OFF` anywhere else: sets RPATH after installation.
 	- `USE_QT5` - autodetect: if Qt >= 5.6.1 is found then it uses Qt5, otherwise it uses Qt4.

--- a/src/qmplay2/LibASS.cpp
+++ b/src/qmplay2/LibASS.cpp
@@ -274,12 +274,12 @@ void LibASS::setASSStyle()
 	}
 
 	bool colorsAndBorders, marginsAndAlignment, fontsAndSpacing;
-	if (settings.get("ApplyToASS/ApplyToASS").toBool())
+	if (settings.getBool("ApplyToASS/ApplyToASS"))
 	{
-		colorsAndBorders = settings.get("ApplyToASS/ColorsAndBorders").toBool();
-		marginsAndAlignment = settings.get("ApplyToASS/MarginsAndAlignment").toBool();
-		fontsAndSpacing = settings.get("ApplyToASS/FontsAndSpacing").toBool();
-		overridePlayRes = settings.get("ApplyToASS/OverridePlayRes").toBool();
+		colorsAndBorders = settings.getBool("ApplyToASS/ColorsAndBorders");
+		marginsAndAlignment = settings.getBool("ApplyToASS/MarginsAndAlignment");
+		fontsAndSpacing = settings.getBool("ApplyToASS/FontsAndSpacing");
+		overridePlayRes = settings.getBool("ApplyToASS/OverridePlayRes");
 	}
 	else
 		colorsAndBorders = marginsAndAlignment = fontsAndSpacing = overridePlayRes = false;
@@ -313,8 +313,8 @@ void LibASS::setASSStyle()
 			style.OutlineColour = assColorFromQColor(settings.get("Subtitles/OutlineColor").value<QColor>());
 			style.BackColour = assColorFromQColor(settings.get("Subtitles/ShadowColor").value<QColor>());
 			style.BorderStyle = 1;
-			style.Outline = settings.get("Subtitles/Outline").toDouble();
-			style.Shadow = settings.get("Subtitles/Shadow").toDouble();
+			style.Outline = settings.getDouble("Subtitles/Outline");
+			style.Shadow = settings.getDouble("Subtitles/Shadow");
 		}
 		else
 		{
@@ -328,10 +328,10 @@ void LibASS::setASSStyle()
 		}
 		if (marginsAndAlignment)
 		{
-			style.MarginL = settings.get("Subtitles/LeftMargin").toInt();
-			style.MarginR = settings.get("Subtitles/RightMargin").toInt();
-			style.MarginV = settings.get("Subtitles/VMargin").toInt();
-			style.Alignment = toASSAlignment(settings.get("Subtitles/Alignment").toInt());
+			style.MarginL = settings.getInt("Subtitles/LeftMargin");
+			style.MarginR = settings.getInt("Subtitles/RightMargin");
+			style.MarginV = settings.getInt("Subtitles/VMargin");
+			style.Alignment = toASSAlignment(settings.getInt("Subtitles/Alignment"));
 			style.Angle = 0;
 		}
 		else
@@ -346,9 +346,9 @@ void LibASS::setASSStyle()
 			free(style.FontName);
 		if (fontsAndSpacing)
 		{
-			style.FontName = strdup(settings.get("Subtitles/FontName").toString().toUtf8().data());
-			style.FontSize = settings.get("Subtitles/FontSize").toInt();
-			style.Spacing = settings.get("Subtitles/Linespace").toDouble();
+			style.FontName = strdup(settings.getString("Subtitles/FontName").toUtf8().data());
+			style.FontSize = settings.getInt("Subtitles/FontSize");
+			style.Spacing = settings.getInt("Subtitles/Linespace");
 			style.ScaleX = style.ScaleY = 1;
 			style.Bold = style.Italic = style.Underline = style.StrikeOut = 0;
 		}
@@ -482,19 +482,19 @@ void LibASS::readStyle(const QString &prefix, ASS_Style *style)
 {
 	if (style->FontName)
 		free(style->FontName);
-	style->FontName = strdup(settings.get(prefix + "/FontName").toString().toUtf8().data());
-	style->FontSize = settings.get(prefix + "/FontSize").toInt();
+	style->FontName = strdup(settings.getString(prefix + "/FontName").toUtf8().data());
+	style->FontSize = settings.getInt(prefix + "/FontSize");
 	style->PrimaryColour = style->SecondaryColour = assColorFromQColor(settings.get(prefix + "/TextColor").value<QColor>());
 	style->OutlineColour = assColorFromQColor(settings.get(prefix + "/OutlineColor").value<QColor>());
 	style->BackColour = assColorFromQColor(settings.get(prefix + "/ShadowColor").value<QColor>());
-	style->Spacing = settings.get(prefix + "/Linespace").toDouble();
+	style->Spacing = settings.getDouble(prefix + "/Linespace");
 	style->BorderStyle = 1;
-	style->Outline = settings.get(prefix + "/Outline").toDouble();
-	style->Shadow = settings.get(prefix + "/Shadow").toDouble();
-	style->Alignment = toASSAlignment(settings.get(prefix + "/Alignment").toInt());
-	style->MarginL = settings.get(prefix + "/LeftMargin").toInt();
-	style->MarginR = settings.get(prefix + "/RightMargin").toInt();
-	style->MarginV = settings.get(prefix + "/VMargin").toInt();
+	style->Outline = settings.getDouble(prefix + "/Outline");
+	style->Shadow = settings.getDouble(prefix + "/Shadow");
+	style->Alignment = toASSAlignment(settings.getInt(prefix + "/Alignment"));
+	style->MarginL = settings.getInt(prefix + "/LeftMargin");
+	style->MarginR = settings.getInt(prefix + "/RightMargin");
+	style->MarginV = settings.getInt(prefix + "/VMargin");
 }
 void LibASS::calcSize()
 {


### PR DESCRIPTION
1. patch b4ad182a34c7860ea993df220e0c73bcdee0d81d - Little code cleanup commit. Use the Settings `getBook`, `getInt`, ... instead of `get().toInt()`. Also, it might be a good idea to add an `toQColor()`, as it is used in various places and is quite logical to be used. Your thoughts?
2. patch bcb1e130d69494d5425ea8d0f8317f3437e39e17 - fix some typos in README.md (used spell check in vim).