### PR TITLE
CMake: use AUTORCC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
 
 add_subdirectory(qmplay2)
 if(CMAKE_VERSION VERSION_LESS 2.8.11)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -83,12 +83,10 @@ set(GUI_RESOURCES
 
 if(USE_QT5)
     qt5_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
-    qt5_add_resources(GUI_RESOURCES_RCC ${GUI_RESOURCES})
 else()
     find_package(Qt4 REQUIRED QtNetwork)
     include("${QT_USE_FILE}")
     qt4_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
-    qt4_add_resources(GUI_RESOURCES_RCC ${GUI_RESOURCES})
 endif()
 
 include_directories(../qmplay2/headers)
@@ -145,7 +143,7 @@ add_executable(QMPlay2 ${WIN32_EXE}
     ${GUI_HDR}
     ${GUI_SRC}
     ${GUI_FORM_HDR}
-    ${GUI_RESOURCES_RCC}
+    ${GUI_RESOURCES}
 )
 
 if(USE_JEMALLOC)

--- a/src/modules/ALSA/CMakeLists.txt
+++ b/src/modules/ALSA/CMakeLists.txt
@@ -30,18 +30,12 @@ set(ALSA_RESOURCES
 
 find_package(ALSA REQUIRED)
 
-if(USE_QT5)
-    qt5_add_resources(ALSA_RESOURCES_RCC ${ALSA_RESOURCES})
-else()
-    qt4_add_resources(ALSA_RESOURCES_RCC ${ALSA_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${ALSA_INCLUDE_DIR})
 
 add_library(${PROJECT_NAME} MODULE
     ${ALSA_HDR}
     ${ALSA_SRC}
-    ${ALSA_RESOURCES_RCC}
+    ${ALSA_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/AudioCD/CMakeLists.txt
+++ b/src/modules/AudioCD/CMakeLists.txt
@@ -29,18 +29,12 @@ set(AudioCD_RESOURCES
 pkg_check_modules(LIBCD libcdio libcddb REQUIRED)
 link_directories(${LIBCD_LIBRARY_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(AudioCD_RESOURCES_RCC ${AudioCD_RESOURCES})
-else()
-    qt4_add_resources(AudioCD_RESOURCES_RCC ${AudioCD_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${LIBCD_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE
     ${AudioCD_HDR}
     ${AudioCD_SRC}
-    ${AudioCD_RESOURCES_RCC}
+    ${AudioCD_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/AudioFilters/CMakeLists.txt
+++ b/src/modules/AudioFilters/CMakeLists.txt
@@ -40,18 +40,12 @@ pkg_check_modules(LIBAVCODEC libavcodec>=55.52.102 REQUIRED)
 pkg_check_modules(LIBAVUTIL libavutil>=52.66.100 REQUIRED)
 link_directories(${LIBAVCODEC_LIBRARY_DIRS} ${LIBAVUTIL_LIBRARY_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(AudioFilters_RESOURCES_RCC ${AudioFilters_RESOURCES})
-else()
-    qt4_add_resources(AudioFilters_RESOURCES_RCC ${AudioFilters_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${LIBAVCODEC_INCLUDE_DIRS} ${LIBAVUTIL_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE
     ${AudioFilters_HDR}
     ${AudioFilters_SRC}
-    ${AudioFilters_RESOURCES_RCC}
+    ${AudioFilters_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/Chiptune/CMakeLists.txt
+++ b/src/modules/Chiptune/CMakeLists.txt
@@ -49,18 +49,12 @@ if(USE_CHIPTUNE_SID)
     list(APPEND Chiptune_LIBS ${LIBSIDPLAYFP_LIBRARIES})
 endif()
 
-if(USE_QT5)
-    qt5_add_resources(Chiptune_RESOURCES_RCC ${Chiptune_RESOURCES})
-else()
-    qt4_add_resources(Chiptune_RESOURCES_RCC ${Chiptune_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${Chiptune_HDR}
     ${Chiptune_SRC}
-    ${Chiptune_RESOURCES_RCC}
+    ${Chiptune_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/DirectX/CMakeLists.txt
+++ b/src/modules/DirectX/CMakeLists.txt
@@ -26,18 +26,12 @@ set(DirectX_RESOURCES
     icon.qrc
 )
 
-if(USE_QT5)
-    qt5_add_resources(DirectX_RESOURCES_RCC ${DirectX_RESOURCES})
-else()
-    qt4_add_resources(DirectX_RESOURCES_RCC ${DirectX_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${DirectX_HDR}
     ${DirectX_SRC}
-    ${DirectX_RESOURCES_RCC}
+    ${DirectX_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/Extensions/CMakeLists.txt
+++ b/src/modules/Extensions/CMakeLists.txt
@@ -56,25 +56,19 @@ if(USE_LASTFM)
     add_definitions(-DUSE_LASTFM)
 endif()
 
-if(USE_QT5)
-    qt5_add_resources(Extensions_RESOURCES_RCC ${Extensions_RESOURCES})
-else()
-    find_package(Qt4 REQUIRED QtNetwork)
-    include("${QT_USE_FILE}")
-    qt4_add_resources(Extensions_RESOURCES_RCC ${Extensions_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${Extensions_HDR}
     ${Extensions_SRC}
-    ${Extensions_RESOURCES_RCC}
+    ${Extensions_RESOURCES}
 )
 
 if(USE_QT5)
     qt5_use_modules(${PROJECT_NAME} Gui Widgets Network ${DBUS})
 else()
+    find_package(Qt4 REQUIRED QtNetwork)
+    include("${QT_USE_FILE}")
     target_link_libraries(${PROJECT_NAME} Qt4::QtCore Qt4::QtGui Qt4::QtNetwork ${DBUS})
 endif()
 

--- a/src/modules/FFmpeg/CMakeLists.txt
+++ b/src/modules/FFmpeg/CMakeLists.txt
@@ -95,12 +95,6 @@ if(USE_FFMPEG_VAAPI OR USE_FFMPEG_VDPAU) # Common HWAccel
     endif()
 endif()
 
-if(USE_QT5)
-    qt5_add_resources(FFmpeg_RESOURCES_RCC ${FFmpeg_RESOURCES})
-else()
-    qt4_add_resources(FFmpeg_RESOURCES_RCC ${FFmpeg_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers
     ${LIBAVFORMAT_INCLUDE_DIRS}
     ${LIBAVCODEC_INCLUDE_DIRS}
@@ -111,7 +105,7 @@ include_directories(../../qmplay2/headers
 add_library(${PROJECT_NAME} MODULE
     ${FFmpeg_HDR}
     ${FFmpeg_SRC}
-    ${FFmpeg_RESOURCES_RCC}
+    ${FFmpeg_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/FileAssociation/CMakeLists.txt
+++ b/src/modules/FileAssociation/CMakeLists.txt
@@ -24,18 +24,12 @@ set(FileAssociation_RESOURCES
     icon.qrc
 )
 
-if(USE_QT5)
-    qt5_add_resources(FileAssociation_RESOURCES_RCC ${FileAssociation_RESOURCES})
-else()
-    qt4_add_resources(FileAssociation_RESOURCES_RCC ${FileAssociation_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${FileAssociation_HDR}
     ${FileAssociation_SRC}
-    ${FileAssociation_RESOURCES_RCC}
+    ${FileAssociation_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/Inputs/CMakeLists.txt
+++ b/src/modules/Inputs/CMakeLists.txt
@@ -30,18 +30,12 @@ set(Inputs_RESOURCES
     icons.qrc
 )
 
-if(USE_QT5)
-    qt5_add_resources(Inputs_RESOURCES_RCC ${Inputs_RESOURCES})
-else()
-    qt4_add_resources(Inputs_RESOURCES_RCC ${Inputs_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${Inputs_HDR}
     ${Inputs_SRC}
-    ${Inputs_RESOURCES_RCC}
+    ${Inputs_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/Modplug/CMakeLists.txt
+++ b/src/modules/Modplug/CMakeLists.txt
@@ -60,16 +60,10 @@ set(Modplug_RESOURCES
 
 include_directories(../../qmplay2/headers libmodplug)
 
-if(USE_QT5)
-    qt5_add_resources(Modplug_RESOURCES_RCC ${Modplug_RESOURCES})
-else()
-    qt4_add_resources(Modplug_RESOURCES_RCC ${Modplug_RESOURCES})
-endif()
-
 add_library(${PROJECT_NAME} MODULE
     ${Modplug_HDR}
     ${Modplug_SRC}
-    ${Modplug_RESOURCES_RCC}
+    ${Modplug_RESOURCES}
 )
 
 if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")

--- a/src/modules/OpenGL2/CMakeLists.txt
+++ b/src/modules/OpenGL2/CMakeLists.txt
@@ -66,18 +66,12 @@ else()
     list(APPEND OpenGL2_SRC OpenGL2Window.cpp OpenGL2Widget.cpp OpenGL2CommonQt5.cpp)
 endif()
 
-if(USE_QT5)
-    qt5_add_resources(OpenGL2_RESOURCES_RCC ${OpenGL2_RESOURCES})
-else()
-    qt4_add_resources(OpenGL2_RESOURCES_RCC ${OpenGL2_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${OpenGL2_HDR}
     ${OpenGL2_SRC}
-    ${OpenGL2_RESOURCES_RCC}
+    ${OpenGL2_RESOURCES}
 )
 
 if(NOT USE_QT5) # Qt4

--- a/src/modules/Playlists/CMakeLists.txt
+++ b/src/modules/Playlists/CMakeLists.txt
@@ -30,16 +30,10 @@ set(Playlists_RESOURCES
 
 include_directories(../../qmplay2/headers)
 
-if(USE_QT5)
-    qt5_add_resources(Playlists_RESOURCES_RCC ${Playlists_RESOURCES})
-else()
-    qt4_add_resources(Playlists_RESOURCES_RCC ${Playlists_RESOURCES})
-endif()
-
 add_library(${PROJECT_NAME} MODULE
     ${Playlists_HDR}
     ${Playlists_SRC}
-    ${Playlists_RESOURCES_RCC}
+    ${Playlists_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/PortAudio/CMakeLists.txt
+++ b/src/modules/PortAudio/CMakeLists.txt
@@ -31,18 +31,12 @@ set(PortAudio_RESOURCES
 pkg_check_modules(LIBPORTAUDIO portaudio-2.0 REQUIRED)
 link_directories(${LIBPORTAUDIO_LIBRARY_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(PortAudio_RESOURCES_RCC ${PortAudio_RESOURCES})
-else()
-    qt4_add_resources(PortAudio_RESOURCES_RCC ${PortAudio_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${LIBPORTAUDIO_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE
     ${PortAudio_HDR}
     ${PortAudio_SRC}
-    ${PortAudio_RESOURCES_RCC}
+    ${PortAudio_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/PulseAudio/CMakeLists.txt
+++ b/src/modules/PulseAudio/CMakeLists.txt
@@ -31,18 +31,12 @@ set(PulseAudio_RESOURCES
 pkg_check_modules(LIBPULSE libpulse-simple REQUIRED)
 link_directories(${LIBPULSE_LIBRARY_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(PulseAudio_RESOURCES_RCC ${PulseAudio_RESOURCES})
-else()
-    qt4_add_resources(PulseAudio_RESOURCES_RCC ${PulseAudio_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${LIBPULSE_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE
     ${PulseAudio_HDR}
     ${PulseAudio_SRC}
-    ${PulseAudio_RESOURCES_RCC}
+    ${PulseAudio_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/QPainter/CMakeLists.txt
+++ b/src/modules/QPainter/CMakeLists.txt
@@ -26,18 +26,12 @@ set(QPainter_RESOURCES
     icon.qrc
 )
 
-if(USE_QT5)
-    qt5_add_resources(QPainter_RESOURCES_RCC ${QPainter_RESOURCES})
-else()
-    qt4_add_resources(QPainter_RESOURCES_RCC ${QPainter_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers)
 
 add_library(${PROJECT_NAME} MODULE
     ${QPainter_HDR}
     ${QPainter_SRC}
-    ${QPainter_RESOURCES_RCC}
+    ${QPainter_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/Subtitles/CMakeLists.txt
+++ b/src/modules/Subtitles/CMakeLists.txt
@@ -30,16 +30,10 @@ set(Subtitles_RESOURCES
 
 include_directories(../../qmplay2/headers)
 
-if(USE_QT5)
-    qt5_add_resources(Subtitles_RESOURCES_RCC ${Subtitles_RESOURCES})
-else()
-    qt4_add_resources(Subtitles_RESOURCES_RCC ${Subtitles_RESOURCES})
-endif()
-
 add_library(${PROJECT_NAME} MODULE
     ${Subtitles_HDR}
     ${Subtitles_SRC}
-    ${Subtitles_RESOURCES_RCC}
+    ${Subtitles_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/VideoFilters/CMakeLists.txt
+++ b/src/modules/VideoFilters/CMakeLists.txt
@@ -37,18 +37,12 @@ set(VideoFilters_RESOURCES
 pkg_check_modules(LIBAVUTIL libavutil>=52.66.100 REQUIRED)
 link_directories(${LIBAVUTIL_LIBRARY_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(VideoFilters_RESOURCES_RCC ${VideoFilters_RESOURCES})
-else()
-    qt4_add_resources(VideoFilters_RESOURCES_RCC ${VideoFilters_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${LIBAVUTIL_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE
     ${VideoFilters_HDR}
     ${VideoFilters_SRC}
-    ${VideoFilters_RESOURCES_RCC}
+    ${VideoFilters_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/Visualizations/CMakeLists.txt
+++ b/src/modules/Visualizations/CMakeLists.txt
@@ -41,16 +41,10 @@ link_directories(${LIBAVCODEC_LIBRARY_DIRS} ${LIBAVUTIL_LIBRARY_DIRS})
 
 include_directories(../../qmplay2/headers ${LIBAVUTIL_INCLUDE_DIRS} ${LIBAVCODEC_INCLUDE_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(Visualizations_RESOURCES_RCC ${Visualizations_RESOURCES})
-else()
-    qt4_add_resources(Visualizations_RESOURCES_RCC ${Visualizations_RESOURCES})
-endif()
-
 add_library(${PROJECT_NAME} MODULE
     ${Visualizations_HDR}
     ${Visualizations_SRC}
-    ${Visualizations_RESOURCES_RCC}
+    ${Visualizations_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/modules/XVideo/CMakeLists.txt
+++ b/src/modules/XVideo/CMakeLists.txt
@@ -31,18 +31,12 @@ set(XVideo_RESOURCES
 pkg_check_modules(LIB_X11_XV x11 xv REQUIRED)
 link_directories(${LIB_X11_XV_LIBRARY_DIRS})
 
-if(USE_QT5)
-    qt5_add_resources(XVideo_RESOURCES_RCC ${XVideo_RESOURCES})
-else()
-    qt4_add_resources(XVideo_RESOURCES_RCC ${XVideo_RESOURCES})
-endif()
-
 include_directories(../../qmplay2/headers ${LIB_X11_XV_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} MODULE
     ${XVideo_HDR}
     ${XVideo_SRC}
-    ${XVideo_RESOURCES_RCC}
+    ${XVideo_RESOURCES}
 )
 
 if(USE_QT5)

--- a/src/qmplay2/CMakeLists.txt
+++ b/src/qmplay2/CMakeLists.txt
@@ -135,18 +135,12 @@ else()
     link_directories(${LIBSWRESAMPLE_LIBRARY_DIRS})
 endif()
 
-if(USE_QT5)
-    qt5_add_resources(QMPLAY2_RESOURCES_RCC ${QMPLAY2_RESOURCES})
-else()
-    qt4_add_resources(QMPLAY2_RESOURCES_RCC ${QMPLAY2_RESOURCES})
-endif()
-
 add_definitions(-D__STDC_CONSTANT_MACROS)
 
 add_library(${PROJECT_NAME} SHARED
     ${QMPLAY2_HDR}
     ${QMPLAY2_SRC}
-    ${QMPLAY2_RESOURCES_RCC}
+    ${QMPLAY2_RESOURCES}
 )
 
 if(USE_QT5)


### PR DESCRIPTION
Use CMake's AUTORCC for better resources usage. Simplifies a little.

This resulted from the cross-compile bug discussed in #31 .