### PR TITLE
Code Cleanup

### DIFF
--- a/src/gui/AddressBox.cpp
+++ b/src/gui/AddressBox.cpp
@@ -43,7 +43,7 @@ AddressBox::AddressBox(Qt::Orientation o, QString url)
 				pB.addItem(icon, mod.name, MODULE);
 			}
 
-	foreach (QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
+	foreach (const QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
 		foreach (const QMPlay2Extensions::AddressPrefix &addressPrefix, QMPlay2Ext->addressPrefixList())
 			pB.addItem(QPixmap::fromImage(addressPrefix.img), addressPrefix, MODULE);
 

--- a/src/gui/MainWidget.cpp
+++ b/src/gui/MainWidget.cpp
@@ -611,7 +611,7 @@ void MainWidget::visualizationFullScreen()
 }
 void MainWidget::hideAllExtensions()
 {
-	foreach(QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
+	foreach (QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
 		if (DockWidget *dw = QMPlay2Ext->getDockWidget())
 			dw->hide();
 }

--- a/src/gui/MainWidget.cpp
+++ b/src/gui/MainWidget.cpp
@@ -491,7 +491,9 @@ void MainWidget::audioChannelsChanged()
 
 void MainWidget::updateWindowTitle(const QString &t)
 {
-	QString title = QCoreApplication::applicationName() + (t.isEmpty() ? QString() : " - " + t);
+	QString title = QCoreApplication::applicationName();
+	if(!t.isEmpty())
+		title += " - " + t;
 	tray->setToolTip(title);
 	title.replace('\n', ' ');
 	setWindowTitle(title);
@@ -1304,7 +1306,7 @@ void MainWidget::mouseMoveEvent(QMouseEvent *e)
 			showToolBar(true); //Before restoring dock widgets - show toolbar and status bar
 			restoreState(fullScreenDockWidgetState);
 
-			QList<QDockWidget *> tDW = tabifiedDockWidgets(infoDock);
+			const QList<QDockWidget *> tDW = tabifiedDockWidgets(infoDock);
 			bool reloadQMPlay2Extensions = false;
 			foreach (QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
 				if (DockWidget *dw = QMPlay2Ext->getDockWidget())

--- a/src/gui/OtherVFiltersW.cpp
+++ b/src/gui/OtherVFiltersW.cpp
@@ -61,7 +61,7 @@ OtherVFiltersW::OtherVFiltersW(bool hw) :
 	else
 	{
 		foreach (Module *pluginInstance, QMPlay2Core.getPluginsInstance())
-			foreach (Module::Info moduleInfo, pluginInstance->getModulesInfo())
+			foreach (const Module::Info &moduleInfo, pluginInstance->getModulesInfo())
 				if ((moduleInfo.type & 0xF) == Module::WRITER && (moduleInfo.type & Module::VIDEOHWFILTER))
 					pluginsInstances += qMakePair(pluginInstance, moduleInfo);
 	}

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -666,7 +666,7 @@ void SettingsWidget::closeEvent(QCloseEvent *)
 
 void SettingsWidget::chStyle()
 {
-	QString newStyle = page1->styleBox->currentText().toLower();
+	const QString newStyle = page1->styleBox->currentText().toLower();
 	if (QApplication::style()->objectName() != newStyle)
 	{
 		QMPlay2Core.getSettings().set("Style", newStyle);
@@ -923,7 +923,7 @@ void SettingsWidget::moveModule()
 }
 void SettingsWidget::chooseScreenshotDir()
 {
-	QString dir = QFileDialog::getExistingDirectory(this, tr("Choose directory"), page1->screenshotE->text());
+	const QString dir = QFileDialog::getExistingDirectory(this, tr("Choose directory"), page1->screenshotE->text());
 	if (!dir.isEmpty())
 		page1->screenshotE->setText(dir);
 }

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -351,7 +351,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 		page1->proxyUserE->setText(QMPSettings.getString("Proxy/User"));
 		page1->proxyPasswordE->setText(QByteArray::fromBase64(QMPSettings.getByteArray("Proxy/Password")));
 
-		QIcon viewRefresh = QMPlay2Core.getIconFromTheme("view-refresh");
+		const QIcon viewRefresh = QMPlay2Core.getIconFromTheme("view-refresh");
 		page1->clearCoversCache->setIcon(viewRefresh);
 		connect(page1->clearCoversCache, SIGNAL(clicked()), this, SLOT(clearCoversCache()));
 		page1->resetSettingsB->setIcon(viewRefresh);
@@ -455,7 +455,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 			QListWidgetItem *tWI = new QListWidgetItem(module->name());
 			tWI->setData(Qt::UserRole, qVariantFromValue((void *)module));
 			QString toolTip = tr("Contains") + ":";
-			foreach (Module::Info mod, module->getModulesInfo(true))
+			foreach (const Module::Info &mod, module->getModulesInfo(true))
 			{
 				toolTip += "<p>&nbsp;&nbsp;&nbsp;&nbsp;";
 				if (!mod.imgPath().isEmpty())

--- a/src/gui/VideoDock.cpp
+++ b/src/gui/VideoDock.cpp
@@ -243,14 +243,16 @@ void VideoDock::wheelEvent(QWheelEvent *e)
 {
 	if (e->orientation() == Qt::Vertical)
 	{
+		Settings &settings = QMPlay2Core.getSettings();
+		MenuBar::Player *player = QMPlay2GUI.menuBar->player;
 		if (e->buttons() & Qt::LeftButton)
-			e->delta() > 0 ? QMPlay2GUI.menuBar->player->zoomIn->trigger() : QMPlay2GUI.menuBar->player->zoomOut->trigger();
-		else if (e->buttons() == Qt::NoButton && QMPlay2Core.getSettings().getBool("WheelAction"))
+			e->delta() > 0 ? player->zoomIn->trigger() : player->zoomOut->trigger();
+		else if (e->buttons() == Qt::NoButton && settings.getBool("WheelAction"))
 		{
-			if (QMPlay2Core.getSettings().getBool("WheelSeek"))
-				e->delta() > 0 ? QMPlay2GUI.menuBar->player->seekF->trigger() : QMPlay2GUI.menuBar->player->seekB->trigger();
-			else if (QMPlay2Core.getSettings().getBool("WheelVolume"))
-				e->delta() > 0 ? QMPlay2GUI.menuBar->player->volUp->trigger() : QMPlay2GUI.menuBar->player->volDown->trigger();
+			if (settings.getBool("WheelSeek"))
+				e->delta() > 0 ? player->seekF->trigger() : player->seekB->trigger();
+			else if (settings.getBool("WheelVolume"))
+				e->delta() > 0 ? player->volUp->trigger() : player->volDown->trigger();
 		}
 	}
 	DockWidget::wheelEvent(e);

--- a/src/modules/Extensions/Downloader.cpp
+++ b/src/modules/Extensions/Downloader.cpp
@@ -426,9 +426,9 @@ QImage DownloaderThread::getImage()
 {
 	if (!prefix.isEmpty())
 	{
-		foreach (QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
+		foreach (const QMPlay2Extensions *QMPlay2Ext, QMPlay2Extensions::QMPlay2ExtensionsList())
 		{
-			QList<QMPlay2Extensions::AddressPrefix> addressPrefixList = QMPlay2Ext->addressPrefixList();
+			const QList<QMPlay2Extensions::AddressPrefix> addressPrefixList = QMPlay2Ext->addressPrefixList();
 			int idx = addressPrefixList.indexOf(prefix);
 			if (idx > -1)
 				return addressPrefixList[idx].img;

--- a/src/modules/Extensions/Downloader.cpp
+++ b/src/modules/Extensions/Downloader.cpp
@@ -73,11 +73,9 @@ DownloadItemW::DownloadItemW(DownloaderThread *downloaderThr, QString name, cons
 	else
 		sizeLText = tr("Waiting for connection");
 
-	titleL = new QLabel;
-	titleL->setText(name);
+	titleL = new QLabel(name);
 
-	sizeL = new QLabel;
-	sizeL->setText(sizeLText);
+	sizeL = new QLabel(sizeLText);
 
 	iconL = new QLabel;
 	iconL->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred));

--- a/src/modules/Extensions/LastFM.cpp
+++ b/src/modules/Extensions/LastFM.cpp
@@ -18,10 +18,10 @@
 
 #include <LastFM.hpp>
 
-static const char audioScrobbler2URL[] = "https://ws.audioscrobbler.com/2.0";
-static const char api_key[] = "b1165c9688c2fcf29fc74c2ab62ffd90";
-static const char secret[]  = "e36ce24a59f45514daad8fccec294c34";
-static const int scrobbleSec = 5;
+#define audioScrobbler2URL "https://ws.audioscrobbler.com/2.0"
+#define api_key "b1165c9688c2fcf29fc74c2ab62ffd90"
+#define secret "e36ce24a59f45514daad8fccec294c34"
+#define scrobbleSec 5
 
 Q_DECLARE_METATYPE(LastFM::Scrobble)
 
@@ -94,11 +94,10 @@ void LastFM::getAlbumCover(const QString &title, const QString &artist, const QS
 
 		const QString trackOrAlbum = (albumEncoded.isEmpty() ? "track" : "album");
 
-		QString url = audioScrobbler2URL;
-		url += QString("/?method=%1.getInfo").arg(trackOrAlbum);
-		url += QString("&api_key=%1").arg(api_key);
-		url += QString("&artist=%1").arg(artistEncoded);
-		url += QString("&%1=%2").arg(trackOrAlbum).arg(albumEncoded.isEmpty() ? titleEncoded : albumEncoded);
+		const QString url = QString(audioScrobbler2URL "/?method=%1.getInfo&api_key=%2&artist=%3&%4=%5").arg(
+				trackOrAlbum, api_key, artistEncoded,
+				trackOrAlbum, (albumEncoded.isEmpty() ? titleEncoded : albumEncoded)
+		);
 
 		if (coverReply)
 		{
@@ -115,12 +114,12 @@ void LastFM::getAlbumCover(const QString &title, const QString &artist, const QS
 
 void LastFM::login()
 {
-	static const QString getSessionURL = audioScrobbler2URL + QString("/?method=auth.getmobilesession&username=%1&authToken=%2&api_key=%3&api_sig=%4");
+	static const QString getSessionURL = QString(audioScrobbler2URL "/?method=auth.getmobilesession&username=%1&authToken=%2&api_key=%3&api_sig=%4");
 	if (!loginReply && !user.isEmpty() && md5pass.length() == 32)
 	{
 		const QString auth_token = QCryptographicHash::hash(user.toUtf8() + md5pass.toUtf8(), QCryptographicHash::Md5).toHex();
-		const QString api_sig = QCryptographicHash::hash(QString("api_key%1authToken%2methodauth.getmobilesessionusername%3%4").arg(api_key).arg(auth_token).arg(user).arg(secret).toUtf8(), QCryptographicHash::Md5).toHex();
-		loginReply = net.get(QNetworkRequest(getSessionURL.arg(user).arg(auth_token).arg(api_key).arg(api_sig)));
+		const QString api_sig = QCryptographicHash::hash(QString("api_key%1authToken%2methodauth.getmobilesessionusername%3%4").arg(api_key, auth_token, user, secret).toUtf8(), QCryptographicHash::Md5).toHex();
+		loginReply = net.get(QNetworkRequest(getSessionURL.arg(user, auth_token, api_key, api_sig)));
 		loginReply->ignoreSslErrors();
 		connect(loginReply, SIGNAL(finished()), this, SLOT(loginFinished()));
 	}

--- a/src/modules/Extensions/ProstoPleer.cpp
+++ b/src/modules/Extensions/ProstoPleer.cpp
@@ -35,15 +35,15 @@
 #include <QClipboard>
 #include <QMimeData>
 
-static QString ProstoPleerURL("http://pleer.net");
+#define ProstoPleerURL "http://pleer.net"
 
 static inline QString getQMPlay2Url(const QTreeWidgetItem *tWI)
 {
-	return ProstoPleerName"://{" + ProstoPleerURL + "/en/tracks/" + tWI->data(0, Qt::UserRole).toString() + "}";
+	return QString(ProstoPleerName "://{" ProstoPleerURL "/en/tracks/%1}").arg(tWI->data(0, Qt::UserRole).toString());
 }
 static inline QString getPageUrl(const QTreeWidgetItem *tWI)
 {
-	return ProstoPleerURL + "/en/tracks/" + tWI->data(0, Qt::UserRole).toString();
+	return QString(ProstoPleerURL "/en/tracks/") + tWI->data(0, Qt::UserRole).toString();
 }
 
 /**/
@@ -206,7 +206,7 @@ void ProstoPleerW::searchTextEdited(const QString &text)
 		((QStringListModel *)completer->model())->setStringList(QStringList());
 	else
 	{
-		QNetworkRequest request(ProstoPleerURL + "/search_suggest");
+		QNetworkRequest request(QString(ProstoPleerURL "/search_suggest"));
 		request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
 		autocompleteReply = net.post(request, QByteArray("part=" + text.toUtf8()));
 	}
@@ -229,7 +229,7 @@ void ProstoPleerW::search()
 	{
 		if (lastName != name || sender() == searchE || sender() == searchB)
 			currPage = 1;
-		searchReply = net.get(QNetworkRequest(ProstoPleerURL + QString("/search?q=%1&page=%2").arg(name).arg(currPage)));
+		searchReply = net.get(QNetworkRequest(QString(ProstoPleerURL "/search?q=%1&page=%2").arg(name, currPage)));
 		progressB->show();
 	}
 	else
@@ -263,7 +263,7 @@ void ProstoPleerW::netFinished(QNetworkReply *reply)
 			{
 				QTextDocument txtDoc;
 				txtDoc.setHtml(replyData.mid(idx1 + 1, idx2 - idx1 - 1));
-				QStringList suggestions = txtDoc.toPlainText().remove('"').split(',');
+				const QStringList suggestions = txtDoc.toPlainText().remove('"').split(',');
 				if (!suggestions.isEmpty())
 				{
 					((QStringListModel *)completer->model())->setStringList(suggestions);
@@ -299,7 +299,7 @@ void ProstoPleerW::netFinished(QNetworkReply *reply)
 				QString bitrate = regexp.cap(6).toLower().remove(' ').replace('/', 'p');
 				if (bitrate == "vbr" && time > 0)
 				{
-					QStringList fSizeList = regexp.cap(7).toLower().split(' ');
+					const QStringList fSizeList = regexp.cap(7).toLower().split(' ');
 					if (fSizeList.count() >= 2 && fSizeList[1] == "mb")
 					{
 						float fSize = fSizeList[0].toFloat();
@@ -386,7 +386,7 @@ void ProstoPleer::convertAddress(const QString &prefix, const QString &url, cons
 			int idx = url.lastIndexOf('/');
 
 			IOController<Reader> &reader = ioCtrl->toRef<Reader>();
-			if (idx > -1 && Reader::create(ProstoPleerURL + "/site_api/files/get_url?id=" + fileId.mid(idx + 1), reader))
+			if (idx > -1 && Reader::create(QString(ProstoPleerURL "/site_api/files/get_url?id=") + fileId.mid(idx + 1), reader))
 			{
 				QByteArray replyData;
 				while (reader->readyRead() && !reader->atEnd() && replyData.size() < 0x200000 /* 2 MiB */)

--- a/src/modules/Extensions/ProstoPleer.cpp
+++ b/src/modules/Extensions/ProstoPleer.cpp
@@ -362,7 +362,7 @@ DockWidget *ProstoPleer::getDockWidget()
 	return w.dw;
 }
 
-QList<ProstoPleer::AddressPrefix> ProstoPleer::addressPrefixList(bool img)
+QList<ProstoPleer::AddressPrefix> ProstoPleer::addressPrefixList(bool img) const
 {
 	return QList<AddressPrefix>() << AddressPrefix(ProstoPleerName, img ? QImage(":/prostopleer") : QImage());
 }

--- a/src/modules/Extensions/ProstoPleer.hpp
+++ b/src/modules/Extensions/ProstoPleer.hpp
@@ -91,7 +91,7 @@ public:
 
 	DockWidget *getDockWidget();
 
-	QList<AddressPrefix> addressPrefixList(bool);
+	QList<AddressPrefix> addressPrefixList(bool) const;
 	void convertAddress(const QString &prefix, const QString &url, const QString &param, QString *stream_url, QString *name, QImage *img, QString *extension, IOController<> *ioCtrl);
 
 	QAction *getAction(const QString &, double, const QString &, const QString &, const QString &);

--- a/src/modules/Extensions/Radio.cpp
+++ b/src/modules/Extensions/Radio.cpp
@@ -134,13 +134,12 @@ void Radio::openLink()
 	{
 		if (lWI == nowaStacjaLWI)
 		{
-			const QString newStation = tr("Adding a new radio station");
-			QString nazwa, adres;
 			bool ok;
-			nazwa = QInputDialog::getText(this, newStation, tr("Name"), QLineEdit::Normal, QString(), &ok);
+			const QString newStation = tr("Adding a new radio station");
+			const QString nazwa = QInputDialog::getText(this, newStation, tr("Name"), QLineEdit::Normal, QString(), &ok);
 			if (ok && !nazwa.isEmpty())
 			{
-				adres = QInputDialog::getText(this, newStation, tr("Address"), QLineEdit::Normal, "http://", &ok);
+				const QString adres = QInputDialog::getText(this, newStation, tr("Address"), QLineEdit::Normal, "http://", &ok);
 				if (ok && !adres.isEmpty() && adres != "http://")
 					addStation(nazwa, adres, wlasneStacje);
 			}

--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -1294,7 +1294,7 @@ DockWidget *YouTube::getDockWidget()
 	return w.dw;
 }
 
-QList<YouTube::AddressPrefix> YouTube::addressPrefixList(bool img)
+QList<YouTube::AddressPrefix> YouTube::addressPrefixList(bool img) const
 {
 	return QList<AddressPrefix>() << AddressPrefix("YouTube", img ? QImage(":/youtube") : QImage()) << AddressPrefix("youtube-dl", img ? QImage(":/video") : QImage());
 }

--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -312,7 +312,7 @@ void ResultsYoutube::mouseMoveEvent(QMouseEvent *e)
 		QString url;
 		if (e->buttons() & Qt::LeftButton)
 			url = getQMPlay2Url(tWI);
-		else if (e->buttons() & Qt::MiddleButton) //Link do strumienia
+		else if (e->buttons() & Qt::MiddleButton) //Link to a stream
 		{
 			QTreeWidgetItem *tWI2 = tWI->parent() ? tWI : getDefaultQuality(tWI);
 			if (tWI2)
@@ -474,7 +474,7 @@ PageSwitcher::PageSwitcher(QWidget *youTubeW)
 	currPageB = new QSpinBox;
 	connect(currPageB, SIGNAL(editingFinished()), youTubeW, SLOT(chPage()));
 	currPageB->setMinimum(1);
-	currPageB->setMaximum(50); //1000 wyników, po 20 wyników na stronę
+	currPageB->setMaximum(50); //1000 results, 20 results per page
 
 	nextB = new QToolButton;
 	connect(nextB, SIGNAL(clicked()), youTubeW, SLOT(next()));

--- a/src/modules/Extensions/YouTube.hpp
+++ b/src/modules/Extensions/YouTube.hpp
@@ -51,6 +51,7 @@ private:
 	QTreeWidgetItem *getDefaultQuality(const QTreeWidgetItem *tWI);
 
 	void removeTmpFile();
+	void playOrEnqueue(const QString &param, QTreeWidgetItem *tWI);
 
 	void mouseMoveEvent(QMouseEvent *);
 
@@ -60,7 +61,6 @@ private slots:
 	void enqueue();
 	void playCurrentEntry();
 	void playEntry(QTreeWidgetItem *tWI);
-	void playOrEnqueue(const QString &param, QTreeWidgetItem *tWI);
 
 	void openPage();
 	void copyPageURL();
@@ -73,7 +73,6 @@ private slots:
 
 class PageSwitcher : public QWidget
 {
-	Q_OBJECT
 public:
 	PageSwitcher(QWidget *youTubeW);
 

--- a/src/modules/Extensions/YouTube.hpp
+++ b/src/modules/Extensions/YouTube.hpp
@@ -149,7 +149,7 @@ public:
 
 	DockWidget *getDockWidget();
 
-	QList<AddressPrefix> addressPrefixList(bool);
+	QList<AddressPrefix> addressPrefixList(bool) const;
 	void convertAddress(const QString &, const QString &, const QString &, QString *, QString *, QImage *, QString *, IOController<> *ioCtrl);
 
 	QAction *getAction(const QString &, double, const QString &, const QString &, const QString &);

--- a/src/modules/FFmpeg/FFDemux.cpp
+++ b/src/modules/FFmpeg/FFDemux.cpp
@@ -45,7 +45,7 @@ bool FFDemux::set()
 bool FFDemux::metadataChanged() const
 {
 	bool isMetadataChanged = false;
-	foreach (FormatContext *fmtCtx, formatContexts)
+	foreach (const FormatContext *fmtCtx, formatContexts)
 		isMetadataChanged |= fmtCtx->metadataChanged();
 	return isMetadataChanged;
 }
@@ -60,7 +60,7 @@ QList<ChapterInfo> FFDemux::getChapters() const
 QString FFDemux::name() const
 {
 	QString name;
-	foreach (FormatContext *fmtCtx, formatContexts)
+	foreach (const FormatContext *fmtCtx, formatContexts)
 	{
 		const QString fmtCtxName = fmtCtx->name();
 		if (!name.contains(fmtCtxName))
@@ -90,14 +90,14 @@ bool FFDemux::getReplayGain(bool album, float &gain_db, float &peak) const
 double FFDemux::length() const
 {
 	double length = -1.0;
-	foreach (FormatContext *fmtCtx, formatContexts)
+	foreach (const FormatContext *fmtCtx, formatContexts)
 		length = qMax(length, fmtCtx->length());
 	return length;
 }
 int FFDemux::bitrate() const
 {
 	int bitrate = 0;
-	foreach (FormatContext *fmtCtx, formatContexts)
+	foreach (const FormatContext *fmtCtx, formatContexts)
 		bitrate += fmtCtx->bitrate();
 	return bitrate;
 }
@@ -110,7 +110,7 @@ QByteArray FFDemux::image(bool forceCopy) const
 
 bool FFDemux::localStream() const
 {
-	foreach (FormatContext *fmtCtx, formatContexts)
+	foreach (const FormatContext *fmtCtx, formatContexts)
 		if (!fmtCtx->isLocal)
 			return false;
 	return true;
@@ -201,7 +201,7 @@ Playlist::Entries FFDemux::fetchTracks(const QString &url, bool &ok)
 	Playlist::Entries entries;
 	if (!url.contains("://{") && url.startsWith("file://"))
 	{
-		OggHelper oggHelper(url.mid(7), abortFetchTracks);
+		const OggHelper oggHelper(url.mid(7), abortFetchTracks);
 		if (oggHelper.io)
 		{
 			int i = 0;

--- a/src/modules/FFmpeg/FormatContext.cpp
+++ b/src/modules/FFmpeg/FormatContext.cpp
@@ -194,7 +194,7 @@ QList<ChapterInfo> FormatContext::getChapters() const
 	QList<ChapterInfo> chapters;
 	for (unsigned i = 0; i < formatCtx->nb_chapters; i++)
 	{
-		AVChapter &chapter = *formatCtx->chapters[i];
+		const AVChapter &chapter = *formatCtx->chapters[i];
 		ChapterInfo chapterInfo(chapter.start * chapter.time_base.num / (double)chapter.time_base.den, chapter.end * chapter.time_base.num / (double)chapter.time_base.den);
 		if (AVDictionaryEntry *avtag = av_dict_get(chapter.metadata, "title", NULL, AV_DICT_IGNORE_SUFFIX))
 			chapterInfo.title = avtag->value;
@@ -372,7 +372,7 @@ int FormatContext::bitrate() const
 }
 QByteArray FormatContext::image(bool forceCopy) const
 {
-	foreach (AVStream *stream, streams)
+	foreach (const AVStream *stream, streams)
 		if (stream->disposition & AV_DISPOSITION_ATTACHED_PIC)
 			return forceCopy ? QByteArray((const char *)stream->attached_pic.data, stream->attached_pic.size) : QByteArray::fromRawData((const char *)stream->attached_pic.data, stream->attached_pic.size);
 	return QByteArray();
@@ -761,7 +761,7 @@ StreamInfo *FormatContext::getStreamInfo(AVStream *stream) const
 
 	StreamInfo *streamInfo = new StreamInfo;
 
-	if (AVCodec *codec = avcodec_find_decoder(codecParams(stream)->codec_id))
+	if (const AVCodec *codec = avcodec_find_decoder(codecParams(stream)->codec_id))
 		streamInfo->codec_name = codec->name;
 
 	streamInfo->must_decode = true;

--- a/src/modules/FFmpeg/OggHelper.cpp
+++ b/src/modules/FFmpeg/OggHelper.cpp
@@ -85,7 +85,7 @@ OggHelper::~OggHelper()
 		avio_close(io);
 }
 
-OggHelper::Chains OggHelper::getOggChains(bool &ok)
+OggHelper::Chains OggHelper::getOggChains(bool &ok) const
 {
 	Chains chains;
 

--- a/src/modules/FFmpeg/OggHelper.hpp
+++ b/src/modules/FFmpeg/OggHelper.hpp
@@ -38,7 +38,7 @@ public:
 	OggHelper(const QString &url, bool &isAborted);
 	~OggHelper();
 
-	Chains getOggChains(bool &ok);
+	Chains getOggChains(bool &ok) const;
 
 private:
 	inline quint32 getSerial(const quint8 *header) const;

--- a/src/modules/Inputs/Inputs.cpp
+++ b/src/modules/Inputs/Inputs.cpp
@@ -212,7 +212,7 @@ void AddD::save()
 QString AddD::execAndGet()
 {
 	if (exec() == QDialog::Accepted)
-		return "{samplerate=" + QString::number(getSampleRate()) + "&freqs=" + getFreqs() + "}";
+		return QString("{samplerate=%1&freqs=%2}").arg(getSampleRate()).arg(getFreqs());
 	return QString();
 }
 

--- a/src/modules/Inputs/PCM.cpp
+++ b/src/modules/Inputs/PCM.cpp
@@ -87,7 +87,7 @@ bool PCM::read(Packet &decoded, int &idx)
 
 	decoded.ts = (reader->pos() - offset) / (double)bytes[fmt] / chn / srate;
 
-	QByteArray dataBA = reader->read(chn * bytes[fmt] * 256);
+	const QByteArray dataBA = reader->read(chn * bytes[fmt] * 256);
 	const int samples_with_channels = dataBA.size() / bytes[fmt];
 	decoded.resize(samples_with_channels * sizeof(float));
 	float *decoded_data = (float *)decoded.data();

--- a/src/modules/Inputs/Rayman2.cpp
+++ b/src/modules/Inputs/Rayman2.cpp
@@ -158,7 +158,7 @@ bool Rayman2::open(const QString &url)
 {
 	if (Reader::create(url, reader))
 	{
-		QByteArray header = reader->read(0x64);
+		const QByteArray header = reader->read(0x64);
 		if (header.size() == 0x64)
 		{
 			const char *data = header.constData();

--- a/src/modules/Playlists/M3U.cpp
+++ b/src/modules/Playlists/M3U.cpp
@@ -92,7 +92,7 @@ bool M3U::write(const Entries &list)
 			if (isFile)
 				url.replace("/", "\\");
 #endif
-			writer->write(QString("#EXTINF:" + length + "," + QString(entry.name).replace('\n', '\001') + "\r\n" + url + "\r\n").toUtf8());
+			writer->write(QString("#EXTINF:%1,%2\r\n%3\r\n").arg(length, QString(entry.name).replace('\n', '\001'), url).toUtf8());
 		}
 	}
 	return true;

--- a/src/modules/Playlists/PLS.cpp
+++ b/src/modules/Playlists/PLS.cpp
@@ -124,7 +124,7 @@ Playlist::Entries PLS::read()
 bool PLS::write(const Entries &list)
 {
 	Writer *writer = ioCtrl.rawPtr<Writer>();
-	writer->write(QString("[playlist]\r\nNumberOfEntries=" + QString::number(list.size()) + "\r\n").toUtf8());
+	writer->write(QString("[playlist]\r\nNumberOfEntries=%1\r\n").arg(list.size()).toUtf8());
 	for (int i = 0; i < list.size(); i++)
 	{
 		const Playlist::Entry &entry = list[i];
@@ -139,22 +139,22 @@ bool PLS::write(const Entries &list)
 #endif
 		}
 		if (!url.isEmpty())
-			writer->write(QString("File" + idx + "=" + url + "\r\n").toUtf8());
+			writer->write(QString("File%1=%2\r\n").arg(idx, url).toUtf8());
 		if (!entry.name.isEmpty())
-			writer->write(QString("Title" + idx + "=" + QString(entry.name).replace('\n', '\001') + "\r\n").toUtf8());
+			writer->write(QString("Title%1=%2\r\n").arg(idx, QString(entry.name).replace('\n', '\001')).toUtf8());
 		if (entry.length >= 0.0)
 		{
-			writer->write(QString("Length" + idx + "=" + QString::number((qint32)(entry.length + 0.5)) + "\r\n").toUtf8());
-			writer->write(QString("QMPlay_length" + idx + "=" + QString::number(entry.length, 'g', 13) + "\r\n").toUtf8());
+			writer->write(QString("Length%1=%2\r\n").arg(idx).arg((qint32)(entry.length + 0.5)).toUtf8());
+			writer->write(QString("QMPlay_length%1=%2\r\n").arg(idx).arg(entry.length, 0, 'g', 13).toUtf8());
 		}
 		if (entry.selected)
-			writer->write(QString("QMPlay_sel" + idx + "=" + QString::number(entry.selected) + "\r\n").toUtf8());
+			writer->write(QString("QMPlay_sel%1=%2\r\n").arg(idx).arg(entry.selected).toUtf8());
 		if (entry.queue)
-			writer->write(QString("QMPlay_queue" + idx + "=" + QString::number(entry.queue) + "\r\n").toUtf8());
+			writer->write(QString("QMPlay_queue%1=%2\r\n").arg(idx).arg(entry.queue).toUtf8());
 		if (entry.GID)
-			writer->write(QString("QMPlay_GID" + idx + "=" + QString::number(entry.GID) + "\r\n").toUtf8());
+			writer->write(QString("QMPlay_GID%1=%2\r\n").arg(idx).arg(entry.GID).toUtf8());
 		if (entry.parent)
-			writer->write(QString("QMPlay_parent" + idx + "=" + QString::number(entry.parent) + "\r\n").toUtf8());
+			writer->write(QString("QMPlay_parent%1=%2\r\n").arg(idx).arg(entry.parent).toUtf8());
 	}
 	return true;
 }

--- a/src/modules/Subtitles/SRT.cpp
+++ b/src/modules/Subtitles/SRT.cpp
@@ -38,7 +38,7 @@ bool SRT::toASS(const QByteArray &srt, LibASS *ass, double)
 		int idx = entry.indexOf('\n');
 		if (idx > -1)
 		{
-			QStringList time = entry.mid(0, idx).split(" --> ");
+			const QStringList time = entry.mid(0, idx).split(" --> ");
 			if (time.size() == 2)
 			{
 				double time_double[2] = {-1.0, -1.0};

--- a/src/qmplay2/Decoder.cpp
+++ b/src/qmplay2/Decoder.cpp
@@ -60,7 +60,7 @@ Decoder *Decoder::create(StreamInfo &streamInfo, Writer *writer, const QStringLi
 	for (int i = 0; i < pluginsInstances.count(); i++)
 	{
 		Module *module = pluginsInstances[i].first;
-		Module::Info &moduleInfo = pluginsInstances[i].second;
+		const Module::Info &moduleInfo = pluginsInstances[i].second;
 		if (!module || moduleInfo.name.isEmpty())
 			continue;
 		Decoder *decoder = (Decoder *)module->createInstance(moduleInfo.name);

--- a/src/qmplay2/Decoder.cpp
+++ b/src/qmplay2/Decoder.cpp
@@ -43,7 +43,9 @@ Decoder *Decoder::create(StreamInfo &streamInfo, Writer *writer, const QStringLi
 		decoder->open(streamInfo);
 		return decoder;
 	}
-	QVector<QPair<Module *, Module::Info> > pluginsInstances(modNames.count());
+
+	typedef QVector<QPair<Module *, Module::Info> > pluginsList_t;
+	pluginsList_t pluginsInstances(modNames.count());
 	foreach (Module *pluginInstance, QMPlay2Core.getPluginsInstance())
 		foreach (const Module::Info &mod, pluginInstance->getModulesInfo())
 			if (mod.type == Module::DECODER)
@@ -57,10 +59,11 @@ Decoder *Decoder::create(StreamInfo &streamInfo, Writer *writer, const QStringLi
 						pluginsInstances[idx] = qMakePair(pluginInstance, mod);
 				}
 			}
-	for (int i = 0; i < pluginsInstances.count(); i++)
+	for(pluginsList_t::const_iterator it = pluginsInstances.constBegin(), end = pluginsInstances.constEnd();
+		it != end; ++it)
 	{
-		Module *module = pluginsInstances[i].first;
-		const Module::Info &moduleInfo = pluginsInstances[i].second;
+		Module *module = it->first;
+		const Module::Info &moduleInfo = it->second;
 		if (!module || moduleInfo.name.isEmpty())
 			continue;
 		Decoder *decoder = (Decoder *)module->createInstance(moduleInfo.name);

--- a/src/qmplay2/Decoder.cpp
+++ b/src/qmplay2/Decoder.cpp
@@ -59,7 +59,7 @@ Decoder *Decoder::create(StreamInfo &streamInfo, Writer *writer, const QStringLi
 						pluginsInstances[idx] = qMakePair(pluginInstance, mod);
 				}
 			}
-	for(pluginsList_t::const_iterator it = pluginsInstances.constBegin(), end = pluginsInstances.constEnd();
+	for (pluginsList_t::const_iterator it = pluginsInstances.constBegin(), end = pluginsInstances.constEnd();
 		it != end; ++it)
 	{
 		Module *module = it->first;

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -120,11 +120,7 @@ QString Functions::timeToStr(double t, bool space)
 	if (t < 0.0)
 		return QString();
 
-	QString separator;
-	if (space)
-		separator = " : ";
-	else
-		separator = ":";
+	const QString separator = (space ? " : " : ":");
 
 	int h, m, s;
 	getHMS(t + 0.5, h, m, s);
@@ -471,7 +467,7 @@ void Functions::getDataIfHasPluginPrefix(const QString &entireUrl, QString *url,
 		const QString extension = fileExt(entireUrl).toLower();
 		if (demuxersInfo.isEmpty())
 		{
-			foreach (Module *module, QMPlay2Core.getPluginsInstance())
+			foreach (const Module *module, QMPlay2Core.getPluginsInstance())
 				foreach (const Module::Info &mod, module->getModulesInfo())
 					if (mod.type == Module::DEMUXER && (mod.name == scheme || mod.extensions.contains(extension)))
 					{

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -60,7 +60,7 @@ QString Functions::Url(QString url, const QString &pth)
 #ifdef Q_OS_WIN
 	url.replace('\\', '/');
 #endif
-	QString scheme = getUrlScheme(url);
+	const QString scheme = getUrlScheme(url);
 #ifdef Q_OS_WIN
 	if (url.startsWith("file:///")) //lokalnie na dysku
 	{

--- a/src/qmplay2/LibASS.cpp
+++ b/src/qmplay2/LibASS.cpp
@@ -306,6 +306,7 @@ void LibASS::setASSStyle()
 	for (int i = 0; i < ass_sub_track->n_styles; i++)
 	{
 		ASS_Style &style = ass_sub_track->styles[i];
+		ass_style *style_copy = ass_sub_styles_copy[i];
 		if (colorsAndBorders)
 		{
 			style.PrimaryColour = assColorFromQColor(settings.getColor("Subtitles/TextColor"));
@@ -318,13 +319,13 @@ void LibASS::setASSStyle()
 		}
 		else
 		{
-			style.PrimaryColour = ass_sub_styles_copy[i]->PrimaryColour;
-			style.SecondaryColour = ass_sub_styles_copy[i]->SecondaryColour;
-			style.OutlineColour = ass_sub_styles_copy[i]->OutlineColour;
-			style.BackColour = ass_sub_styles_copy[i]->BackColour;
-			style.BorderStyle = ass_sub_styles_copy[i]->BorderStyle;
-			style.Outline = ass_sub_styles_copy[i]->Outline;
-			style.Shadow = ass_sub_styles_copy[i]->Shadow;
+			style.PrimaryColour = style_copy->PrimaryColour;
+			style.SecondaryColour = style_copy->SecondaryColour;
+			style.OutlineColour = style_copy->OutlineColour;
+			style.BackColour = style_copy->BackColour;
+			style.BorderStyle = style_copy->BorderStyle;
+			style.Outline = style_copy->Outline;
+			style.Shadow = style_copy->Shadow;
 		}
 		if (marginsAndAlignment)
 		{
@@ -336,11 +337,11 @@ void LibASS::setASSStyle()
 		}
 		else
 		{
-			style.MarginL = ass_sub_styles_copy[i]->MarginL;
-			style.MarginR = ass_sub_styles_copy[i]->MarginR;
-			style.MarginV = ass_sub_styles_copy[i]->MarginV;
-			style.Alignment = ass_sub_styles_copy[i]->Alignment;
-			style.Angle = ass_sub_styles_copy[i]->Angle;
+			style.MarginL = style_copy->MarginL;
+			style.MarginR = style_copy->MarginR;
+			style.MarginV = style_copy->MarginV;
+			style.Alignment = style_copy->Alignment;
+			style.Angle = style_copy->Angle;
 		}
 		if (style.FontName)
 			free(style.FontName);
@@ -354,18 +355,15 @@ void LibASS::setASSStyle()
 		}
 		else
 		{
-			if (ass_sub_styles_copy[i]->FontName)
-				style.FontName = strdup(ass_sub_styles_copy[i]->FontName);
-			else
-				style.FontName = NULL;
-			style.FontSize = ass_sub_styles_copy[i]->FontSize;
-			style.Spacing = ass_sub_styles_copy[i]->Spacing;
-			style.ScaleX = ass_sub_styles_copy[i]->ScaleX;
-			style.ScaleY = ass_sub_styles_copy[i]->ScaleY;
-			style.Bold = ass_sub_styles_copy[i]->Bold;
-			style.Italic = ass_sub_styles_copy[i]->Italic;
-			style.Underline = ass_sub_styles_copy[i]->Underline;
-			style.StrikeOut = ass_sub_styles_copy[i]->StrikeOut;
+			style.FontName = (style_copy->FontName ? strdup(style_copy->FontName) : NULL);
+			style.FontSize = style_copy->FontSize;
+			style.Spacing = style_copy->Spacing;
+			style.ScaleX = style_copy->ScaleX;
+			style.ScaleY = style_copy->ScaleY;
+			style.Bold = style_copy->Bold;
+			style.Italic = style_copy->Italic;
+			style.Underline = style_copy->Underline;
+			style.StrikeOut = style_copy->StrikeOut;
 		}
 	}
 }

--- a/src/qmplay2/Playlist.cpp
+++ b/src/qmplay2/Playlist.cpp
@@ -67,7 +67,7 @@ Playlist::~Playlist()
 
 Playlist *Playlist::create(const QString &url, OpenMode openMode, QString *name)
 {
-	QString extension = Functions::fileExt(url).toLower();
+	const QString extension = Functions::fileExt(url).toLower();
 	if (extension.isEmpty())
 		return NULL;
 	foreach (Module *module, QMPlay2Core.getPluginsInstance())

--- a/src/qmplay2/Playlist.cpp
+++ b/src/qmplay2/Playlist.cpp
@@ -55,7 +55,7 @@ QString Playlist::name(const QString &url)
 QStringList Playlist::extensions()
 {
 	QStringList extensions;
-	foreach (Module *module, QMPlay2Core.getPluginsInstance())
+	foreach (const Module *module, QMPlay2Core.getPluginsInstance())
 		foreach (const Module::Info &mod, module->getModulesInfo())
 			if (mod.type == Module::PLAYLIST)
 				extensions += mod.extensions;

--- a/src/qmplay2/QMPlay2Extensions.cpp
+++ b/src/qmplay2/QMPlay2Extensions.cpp
@@ -50,7 +50,7 @@ DockWidget *QMPlay2Extensions::getDockWidget()
 	return NULL;
 }
 
-QList<QMPlay2Extensions::AddressPrefix> QMPlay2Extensions::addressPrefixList(bool img)
+QList<QMPlay2Extensions::AddressPrefix> QMPlay2Extensions::addressPrefixList(bool img) const
 {
 	Q_UNUSED(img)
 	return QList<AddressPrefix>();

--- a/src/qmplay2/Reader.cpp
+++ b/src/qmplay2/Reader.cpp
@@ -74,7 +74,7 @@ class QMPlay2FileReader : public Reader
 
 bool Reader::create(const QString &url, IOController<Reader> &reader, const QString &plugName)
 {
-	QString scheme = Functions::getUrlScheme(url);
+	const QString scheme = Functions::getUrlScheme(url);
 	if (reader.isAborted() || url.isEmpty() || scheme.isEmpty())
 		return false;
 	if (plugName.isEmpty() && scheme == "file" && reader.assign(new QMPlay2FileReader))

--- a/src/qmplay2/SubsDec.cpp
+++ b/src/qmplay2/SubsDec.cpp
@@ -38,7 +38,7 @@ SubsDec *SubsDec::create(const QString &type)
 QStringList SubsDec::extensions()
 {
 	QStringList extensions;
-	foreach (Module *module, QMPlay2Core.getPluginsInstance())
+	foreach (const Module *module, QMPlay2Core.getPluginsInstance())
 		foreach (const Module::Info &mod, module->getModulesInfo())
 			if (mod.type == Module::SUBSDEC)
 				extensions << mod.extensions;

--- a/src/qmplay2/Writer.cpp
+++ b/src/qmplay2/Writer.cpp
@@ -83,7 +83,7 @@ Writer *Writer::create(const QString &url, const QStringList &modNames)
 						pluginsInstances[idx] = qMakePair(pluginInstance, mod);
 				}
 			}
-	for(pluginsList_t::const_iterator it = pluginsInstances.constBegin(), end = pluginsInstances.constEnd();
+	for (pluginsList_t::const_iterator it = pluginsInstances.constBegin(), end = pluginsInstances.constEnd();
 		it != end; ++it)
 	{
 		Module *module = it->first;

--- a/src/qmplay2/Writer.cpp
+++ b/src/qmplay2/Writer.cpp
@@ -67,7 +67,9 @@ Writer *Writer::create(const QString &url, const QStringList &modNames)
 		delete writer;
 		return NULL;
 	}
-	QVector<QPair<Module *, Module::Info> > pluginsInstances(modNames.count());
+
+	typedef QVector<QPair<Module *, Module::Info> > pluginsList_t;
+	pluginsList_t pluginsInstances(modNames.count());
 	foreach (Module *pluginInstance, QMPlay2Core.getPluginsInstance())
 		foreach (const Module::Info &mod, pluginInstance->getModulesInfo())
 			if (mod.type == Module::WRITER && mod.extensions.contains(scheme))
@@ -81,10 +83,11 @@ Writer *Writer::create(const QString &url, const QStringList &modNames)
 						pluginsInstances[idx] = qMakePair(pluginInstance, mod);
 				}
 			}
-	for (int i = 0; i < pluginsInstances.count(); i++)
+	for(pluginsList_t::const_iterator it = pluginsInstances.constBegin(), end = pluginsInstances.constEnd();
+		it != end; ++it)
 	{
-		Module *module = pluginsInstances[i].first;
-		Module::Info &moduleInfo = pluginsInstances[i].second;
+		Module *module = it->first;
+		const Module::Info &moduleInfo = it->second;
 		if (!module || moduleInfo.name.isEmpty())
 			continue;
 		writer = (Writer *)module->createInstance(moduleInfo.name);

--- a/src/qmplay2/headers/QMPlay2Extensions.hpp
+++ b/src/qmplay2/headers/QMPlay2Extensions.hpp
@@ -57,7 +57,7 @@ public:
 
 	virtual DockWidget *getDockWidget();
 
-	virtual QList<AddressPrefix> addressPrefixList(bool img = true);
+	virtual QList<AddressPrefix> addressPrefixList(bool img = true) const;
 	virtual void convertAddress(const QString &, const QString &, const QString &, QString *, QString *, QImage *, QString *extension, IOController<> *ioCtrl);
 
 	virtual QAction *getAction(const QString &name, double length, const QString &url, const QString &prefix = QString(), const QString &param = QString());


### PR DESCRIPTION
This Pull Request is a collection of various code clean up:

1. patch bb502bedbc8c03ad98ead59f40d3742728fabd13 - better `QLabel` create and making YouTube::playOrEnqueue as a non slot function.
2. patch fccbad8c993c813d6d953d1ade5f7783ca6667b8 - set `QMPlay2Extensions::addressPrefixList` as a const function (quite logical from its purpose). Enables settings more const calls.
3. patch 8fc008001dd22e288bbc538e953846a5b691826c - adding const around many objects in the code.
4. patch 85292dca5974ce40b84d72c5fd6fb949efdeac23 - use `QString::arg` instead of string appending. Making the code a little bit more readable, smaller binary size and nearly none performance change (changed between 2% more or 2% less which is negligible).
5. patch 932427b22b61875c5a4682c0da01b0b44b1c2f71 - like the previous one. Also use more define string than `static QString`.
6. patch b220140e7ecb6ea1d309ef61aa75c344aea9c6f7 - like the previous one.
7. patch 1177fa054f6cd286a7a8603d080fe8d95f2486af - like the previous one.
8. patch b92441b7c8374f4c42a5f63466e9e822ad8b2e67 - some `if` change and more const.

Most of the code changes are trivial, but I'm asking you **to check** the `QString::arg` changes (4-7). Even though I checked the changes, I might have missed something (mistake here might be a critical one).

The difference between before and after this patch set is around 10KB on my machine (Gentoo + GCC 5.4).

---

On another note about the future: from tomorrow onwards I won't be able to help or answer (except sometimes during Saturday and maybe Friday) as I'm enlisted to the army for the following three years. So no problems to send requests or questions, but please know that it will take time for me to answer.