### PR TITLE
Use user_agent for FFmpeg >= 3.2

### DIFF
--- a/src/modules/FFmpeg/FFCommon.cpp
+++ b/src/modules/FFmpeg/FFCommon.cpp
@@ -40,7 +40,11 @@ QString FFCommon::prepareUrl(QString url, AVDictionary *&options)
 		if (url.startsWith("http"))
 			av_dict_set(&options, "icy", "1", 0);
 #endif
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 56, 100)
+		av_dict_set(&options, "user_agent", QMPlay2UserAgent, 0);
+#else
 		av_dict_set(&options, "user-agent", QMPlay2UserAgent, 0);
+#endif
 	}
 	return url;
 }

--- a/src/qmplay2/Http.cpp
+++ b/src/qmplay2/Http.cpp
@@ -72,7 +72,11 @@ private:
 		else
 		{
 			AVDictionary *options = NULL;
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 56, 100)
+			av_dict_set(&options, "user_agent", m_userAgent, 0);
+#else
 			av_dict_set(&options, "user-agent", m_userAgent, 0);
+#endif
 			av_dict_set(&options, "seekable", "0", 0);
 #if LIBAVFORMAT_VERSION_MAJOR > 55
 			av_dict_set(&options, "icy", "0", 0);


### PR DESCRIPTION
Since FFmpeg version 3.2 user-agent option is deprecated, and we should use user_agent instead. 
[This](https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/27714b462d1bff9e9b40fbdabb39f58e79032b81) commit made this change.