### PR TITLE
Profiles

### DIFF
--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -602,7 +602,7 @@ int main(int argc, char *argv[])
 		new MainWidget(QMPArguments);
 		QCoreApplication::exec();
 
-		const QString settingsDir = QMPlay2Core.getSettingsDir();
+		const QString settingsDir = QMPlay2Core.getSettingsDir() + QMPlay2Core.getSettingsProfile();
 		QMPlay2Core.quit();
 		if (qmplay2Gui.removeSettings)
 			foreach (const QString &fName, QDir(settingsDir).entryList(QStringList("*.ini")))

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -602,11 +602,18 @@ int main(int argc, char *argv[])
 		new MainWidget(QMPArguments);
 		QCoreApplication::exec();
 
-		const QString settingsDir = QMPlay2Core.getSettingsDir() + QMPlay2Core.getSettingsProfile();
+		const QString settingsDir = QMPlay2Core.getSettingsDir();
+		const QString profile = QMPlay2Core.getSettingsProfile();
+		const QString settingsDirProfile = settingsDir + profile;
 		QMPlay2Core.quit();
 		if (qmplay2Gui.removeSettings)
-			foreach (const QString &fName, QDir(settingsDir).entryList(QStringList("*.ini")))
-				QFile::remove(settingsDir + fName);
+		{
+			foreach (const QString &fName, QDir(settingsDirProfile).entryList(QStringList("*.ini")))
+				QFile::remove(settingsDirProfile + fName);
+			if (profile != "/")
+				QDir(settingsDir).rmdir(profile);
+		}
+
 
 		delete qmplay2Gui.pipe;
 	} while (qmplay2Gui.restartApp);

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -345,6 +345,7 @@ MenuBar::Options::Options(MenuBar *parent) :
 	const QIcon configureIcon = QMPlay2Core.getIconFromTheme("configure");
 	newAction(Options::tr("&Settings"), this, settings, false, configureIcon, false);
 	newAction(Options::tr("&Modules settings"), this, modulesSettings, false, configureIcon, false);
+	addSeparator();
 	{
 		QMenu *profiles = new QMenu(Options::tr("&Profiles"), this);
 		profiles->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -361,7 +362,7 @@ MenuBar::Options::Options(MenuBar *parent) :
 			profiles->addAction(profile, parent, SLOT(changeProfile()))->setProperty("path", profile);
 		}
 
-		this->addMenu(profiles);
+		addMenu(profiles);
 	}
 
 	addSeparator();

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -558,7 +558,7 @@ void MenuBar::removeProfile()
 	if (QAction *act = (QAction *)options->removeProfileMenu->property("profile").value<void *>())
 	{
 		const QString &profile = "Profiles/" + act->property("path").toString() + "/";
-		if(profile == QMPlay2Core.getSettingsProfile())
+		if (profile == QMPlay2Core.getSettingsProfile())
 		{
 			QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
 			profileSettings.setValue("Profile", "/");

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -490,7 +490,7 @@ void MenuBar::changeProfile()
 	QAction *act = (QAction *)sender();
 	const QString selectedProfile = act->property("path").toString();
 	QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
-	if(selectedProfile != profileSettings.value("Profile", "/").toString())
+	if (selectedProfile != profileSettings.value("Profile", "/").toString())
 	{
 		profileSettings.setValue("Profile", selectedProfile);
 		QMPlay2GUI.restartApp = true;
@@ -503,10 +503,10 @@ void MenuBar::addProfile()
 	const QString selectedProfile = Functions::cleanFileName(QInputDialog::getText(
 				this, Options::tr("Create new profile"),
 				Options::tr("Profile name")));
-	if(selectedProfile.isEmpty())
+	if (selectedProfile.isEmpty())
 		return;
 	QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
-	if(selectedProfile != profileSettings.value("Profile", "/").toString())
+	if (selectedProfile != profileSettings.value("Profile", "/").toString())
 	{
 		profileSettings.setValue("Profile", selectedProfile);
 		QMPlay2GUI.restartApp = true;

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -506,47 +506,47 @@ void MenuBar::changeProfile()
 		QMPlay2GUI.mainW->close();
 	}
 }
-void MenuBar::addProfile()
+static QString createAndSetProfile(MenuBar *menuBar)
 {
 	const QString selectedProfile = Functions::cleanFileName(QInputDialog::getText(
-				this, Options::tr("Create new profile"),
-				Options::tr("Profile name")));
-	if (selectedProfile.isEmpty())
-		return;
-	QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
-	if (selectedProfile != profileSettings.value("Profile", "/").toString())
+				menuBar, MenuBar::Options::tr("Create new profile"),
+				MenuBar::Options::tr("Profile name")));
+	if (!selectedProfile.isEmpty())
 	{
-		QDir(QMPlay2Core.getSettingsDir()).mkpath("Profiles/" + selectedProfile);
+		QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
+		if (selectedProfile != profileSettings.value("Profile", "/").toString())
+		{
+			QDir(QMPlay2Core.getSettingsDir()).mkpath("Profiles/" + selectedProfile);
+
+			profileSettings.setValue("Profile", selectedProfile);
+			QMPlay2GUI.restartApp = true;
+			QMPlay2GUI.mainW->close();
+			return selectedProfile;
+		}
+	}
+	return QString();
+}
+void MenuBar::addProfile()
+{
+	const QString selectedProfile = createAndSetProfile(this);
+	if (!selectedProfile.isEmpty())
+	{
 		QFile tempFile(QMPlay2Core.getSettingsDir() + "Profiles/" + selectedProfile + "/QMPlay2.ini");
 		tempFile.open(QFile::WriteOnly);
 		tempFile.close();
-
-		profileSettings.setValue("Profile", selectedProfile);
-		QMPlay2GUI.restartApp = true;
-		QMPlay2GUI.mainW->close();
 	}
 }
 void MenuBar::copyProfile()
 {
-	const QString selectedProfile = Functions::cleanFileName(QInputDialog::getText(
-				this, Options::tr("Create new profile"),
-				Options::tr("Profile name")));
-	if (selectedProfile.isEmpty())
-		return;
-	QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
-	if (selectedProfile != profileSettings.value("Profile", "/").toString())
+	const QString selectedProfile = createAndSetProfile(this);
+	if (!selectedProfile.isEmpty())
 	{
-		QDir(QMPlay2Core.getSettingsDir()).mkpath("Profiles/" + selectedProfile);
 		const QString srcDir = QMPlay2Core.getSettingsDir() + QMPlay2Core.getSettingsProfile() + "/";
 		const QString dstDir = QMPlay2Core.getSettingsDir() + "Profiles/" + selectedProfile + "/";
 		foreach (const QString &path, QDir(srcDir).entryList(QStringList() << "*.ini", QDir::Files))
 		{
 			QFile::copy(srcDir + path, dstDir + path);
 		}
-
-		profileSettings.setValue("Profile", selectedProfile);
-		QMPlay2GUI.restartApp = true;
-		QMPlay2GUI.mainW->close();
 	}
 }
 void MenuBar::removeProfileMenuRequest(const QPoint &p)

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -350,6 +350,7 @@ MenuBar::Options::Options(MenuBar *parent) :
 		profiles->setIcon(configureIcon);
 
 		profiles->addAction(QMPlay2Core.getIconFromTheme("list-add"), Options::tr("&New Profile"), parent, SLOT(addProfile()));
+		profiles->addAction(QMPlay2Core.getIconFromTheme("edit-copy"), Options::tr("&Copy Profile"), parent, SLOT(copyProfile()));
 		profiles->addSeparator();
 		profiles->addAction("default", parent, SLOT(changeProfile()))->setProperty("path", "/");
 
@@ -514,6 +515,30 @@ void MenuBar::addProfile()
 		QFile tempFile(QMPlay2Core.getSettingsDir() + "profiles/" + selectedProfile + "/QMPlay2.ini");
 		tempFile.open(QFile::WriteOnly);
 		tempFile.close();
+
+		profileSettings.setValue("Profile", selectedProfile);
+		QMPlay2GUI.restartApp = true;
+		QMPlay2GUI.mainW->close();
+	}
+}
+
+void MenuBar::copyProfile()
+{
+	const QString selectedProfile = Functions::cleanFileName(QInputDialog::getText(
+				this, Options::tr("Create new profile"),
+				Options::tr("Profile name")));
+	if (selectedProfile.isEmpty())
+		return;
+	QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
+	if (selectedProfile != profileSettings.value("Profile", "/").toString())
+	{
+		QDir(QMPlay2Core.getSettingsDir()).mkpath("profiles/" + selectedProfile);
+		const QString srcDir = QMPlay2Core.getSettingsDir() + QMPlay2Core.getSettingsProfile() + "/";
+		const QString dstDir = QMPlay2Core.getSettingsDir() + "profiles/" + selectedProfile + "/";
+		foreach (const QString &path, QDir(srcDir).entryList(QStringList() << "*.ini", QDir::Files))
+		{
+			QFile::copy(srcDir + path, dstDir + path);
+		}
 
 		profileSettings.setValue("Profile", selectedProfile);
 		QMPlay2GUI.restartApp = true;

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -25,9 +25,11 @@
 #include <ShortcutHandler.hpp>
 #include <Functions.hpp>
 
-#include <QWidgetAction>
-#include <QMainWindow>
+#include <QDir>
+#include <QFile>
 #include <QInputDialog>
+#include <QMainWindow>
+#include <QWidgetAction>
 
 static QAction *newAction(const QString &txt, QMenu *parent, QAction *&act, bool autoRepeat, const QIcon &icon, bool checkable)
 {
@@ -508,6 +510,11 @@ void MenuBar::addProfile()
 	QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
 	if (selectedProfile != profileSettings.value("Profile", "/").toString())
 	{
+		QDir(QMPlay2Core.getSettingsDir()).mkpath("profiles/" + selectedProfile);
+		QFile tempFile(QMPlay2Core.getSettingsDir() + "profiles/" + selectedProfile + "/QMPlay2.ini");
+		tempFile.open(QFile::WriteOnly);
+		tempFile.close();
+
 		profileSettings.setValue("Profile", selectedProfile);
 		QMPlay2GUI.restartApp = true;
 		QMPlay2GUI.mainW->close();

--- a/src/gui/MenuBar.hpp
+++ b/src/gui/MenuBar.hpp
@@ -161,6 +161,7 @@ public:
 public slots:
 	void changeProfile();
 	void addProfile();
+	void copyProfile();
 private slots:
 	void widgetsMenuShow();
 };

--- a/src/gui/MenuBar.hpp
+++ b/src/gui/MenuBar.hpp
@@ -158,6 +158,8 @@ public:
 	Playback *playback;
 	Options *options;
 	Help *help;
+public slots:
+	void changeProfile();
 private slots:
 	void widgetsMenuShow();
 };

--- a/src/gui/MenuBar.hpp
+++ b/src/gui/MenuBar.hpp
@@ -160,6 +160,7 @@ public:
 	Help *help;
 public slots:
 	void changeProfile();
+	void addProfile();
 private slots:
 	void widgetsMenuShow();
 };

--- a/src/gui/MenuBar.hpp
+++ b/src/gui/MenuBar.hpp
@@ -135,6 +135,7 @@ public:
 	public:
 		Options(MenuBar *parent);
 		QAction *settings, *modulesSettings, *trayVisible;
+		QMenu *removeProfileMenu;
 	};
 
 	class Help : public QMenu
@@ -162,6 +163,8 @@ public slots:
 	void changeProfile();
 	void addProfile();
 	void copyProfile();
+	void removeProfileMenuRequest(const QPoint &p);
+	void removeProfile();
 private slots:
 	void widgetsMenuShow();
 };

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -311,7 +311,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 				page1->subsLangB->setCurrentIndex(page1->subsLangB->count() - 1);
 		}
 		{
-			page1->profileB->addItem("Default", "/");
+			page1->profileB->addItem(tr("Default"), "/");
 			foreach (const QString &profile, QDir(QMPlay2Core.getSettingsDir() + "Profiles/").entryList(QDir::Dirs | QDir::NoDotAndDotDot))
 			{
 				page1->profileB->addItem(profile, profile);
@@ -991,7 +991,7 @@ void SettingsWidget::removeProfile()
 	if (selectedProfile != "/")
 		QDir(QMPlay2Core.getSettingsDir()).rmdir(selectedProfile);
 
-	if(selectedProfile == QMPlay2Core.getSettingsProfile())
+	if (selectedProfile == QMPlay2Core.getSettingsProfile())
 	{
 		QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
 		profileSettings.setValue("Profile", "/");

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -317,7 +317,7 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 				page1->profileB->addItem(profile, profile);
 			}
 			QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
-			if(QMPlay2Core.getSettingsProfile() != "/")
+			if (QMPlay2Core.getSettingsProfile() != "/")
 				page1->profileB->setCurrentText(profileSettings.value("Profile", "/").toString());
 		}
 
@@ -738,7 +738,7 @@ void SettingsWidget::apply()
 
 			QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
 			const QString selectedProfile = page1->profileB->currentData().toString();
-			if(selectedProfile != profileSettings.value("Profile", "/").toString())
+			if (selectedProfile != profileSettings.value("Profile", "/").toString())
 			{
 				profileSettings.setValue("Profile", page1->profileB->currentData());
 				restartApp();

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -21,6 +21,7 @@
 #include <DeintSettingsW.hpp>
 #include <OtherVFiltersW.hpp>
 #include <OSDSettingsW.hpp>
+#include <Functions.hpp>
 #include <Main.hpp>
 
 #if QT_VERSION < 0x050000
@@ -48,8 +49,6 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QLabel>
-#include <QDir>
-#include <QDirIterator>
 
 #include <KeyBindingsDialog.hpp>
 #include <Appearance.hpp>
@@ -313,17 +312,13 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 		}
 		{
 			page1->profileB->addItem("default", "/");
-			QDirIterator it(QMPlay2Core.getSettingsDir() + "profiles/", QStringList() << "QMPlay2.ini", QDir::Files, QDirIterator::Subdirectories);
-			while (it.hasNext())
+			foreach (const QString &profile, Functions::getProfiles())
 			{
-				const QString path = it.next();
-				const int right = QMPlay2Core.getSettingsDir().length() + strlen("profiles/");
-				const int left = strlen("/QMPlay2.ini");
-				const QString profile = path.mid(right, path.length() - right - left);
 				page1->profileB->addItem(profile, profile);
 			}
+			QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
 			if(QMPlay2Core.getSettingsProfile() != "/")
-				page1->profileB->setCurrentText(QMPlay2Core.getSettingsProfile());
+				page1->profileB->setCurrentText(profileSettings.value("Profile", "/").toString());
 		}
 
 		page1->screenshotE->setText(QMPSettings.getString("screenshotPth"));
@@ -746,8 +741,7 @@ void SettingsWidget::apply()
 			if(selectedProfile != profileSettings.value("Profile", "/").toString())
 			{
 				profileSettings.setValue("Profile", page1->profileB->currentData());
-				// TODO: restart the app
-				QMessageBox::warning(this, "Profile Change", "To see updated profile change\nPlease Restart the app!");
+				restartApp();
 			}
 		} break;
 		case 2:

--- a/src/gui/SettingsWidget.cpp
+++ b/src/gui/SettingsWidget.cpp
@@ -318,7 +318,14 @@ SettingsWidget::SettingsWidget(int page, const QString &moduleName, QWidget *vid
 			}
 			QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
 			if (QMPlay2Core.getSettingsProfile() != "/")
+			{
 				page1->profileB->setCurrentText(profileSettings.value("Profile", "/").toString());
+				page1->profileRemoveB->setDisabled(true);
+			}
+			connect(page1->profileB, SIGNAL(currentIndexChanged(int)), this, SLOT(profileListIndexChanged(int)));
+
+			page1->profileRemoveB->setIcon(QMPlay2Core.getIconFromTheme("list-remove"));
+			connect(page1->profileRemoveB, SIGNAL(clicked()), this, SLOT(removeProfile()));
 		}
 
 		page1->screenshotE->setText(QMPSettings.getString("screenshotPth"));
@@ -972,4 +979,23 @@ void SettingsWidget::resetSettings()
 		QMPlay2GUI.removeSettings = true;
 		restartApp();
 	}
+}
+void SettingsWidget::profileListIndexChanged(int index)
+{
+	page1->profileRemoveB->setEnabled(index != 0);
+}
+void SettingsWidget::removeProfile()
+{
+	const QString selectedProfile = page1->profileB->currentData().toString();
+	Functions::dirRemoveRecursively(QMPlay2Core.getSettingsDir() + "Profiles/" + selectedProfile);
+
+	if("Profiles/" + selectedProfile + "/" == QMPlay2Core.getSettingsProfile())
+	{
+		QSettings profileSettings(QMPlay2Core.getSettingsDir() + "Profile.ini", QSettings::IniFormat);
+		profileSettings.setValue("Profile", "/");
+		QMPlay2GUI.removeSettings = true;
+		restartApp();
+	}
+	else
+		page1->profileB->removeItem(page1->profileB->currentIndex());
 }

--- a/src/gui/SettingsWidget.hpp
+++ b/src/gui/SettingsWidget.hpp
@@ -85,6 +85,8 @@ private slots:
 	void setKeyBindings();
 	void clearCoversCache();
 	void resetSettings();
+	void profileListIndexChanged(int index);
+	void removeProfile();
 signals:
 	void settingsChanged(int, bool);
 	void setWheelStep(int);

--- a/src/gui/Ui/SettingsGeneral.ui
+++ b/src/gui/Ui/SettingsGeneral.ui
@@ -198,7 +198,18 @@
           </widget>
          </item>
          <item row="7" column="1">
-          <widget class="QComboBox" name="profileB"/>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QComboBox" name="profileB"/>
+           </item>
+           <item>
+            <widget class="QToolButton" name="profileRemoveB">
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/src/gui/Ui/SettingsGeneral.ui
+++ b/src/gui/Ui/SettingsGeneral.ui
@@ -190,6 +190,16 @@
            </property>
           </widget>
          </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="profileL">
+           <property name="text">
+            <string>Selected Profile</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QComboBox" name="profileB"/>
+         </item>
         </layout>
        </item>
        <item row="2" column="0">

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -27,6 +27,7 @@
 #include <QMimeData>
 #include <QPainter>
 #include <QDir>
+#include <QDirIterator>
 #include <QUrl>
 
 #include <math.h>
@@ -611,4 +612,20 @@ bool Functions::wrapMouse(QWidget *widget, QPoint &mousePos, int margin)
 		QCursor::setPos(widget->mapToGlobal(mousePos));
 
 	return doWrap;
+}
+
+QStringList Functions::getProfiles()
+{
+	QStringList profiles;
+
+	QDirIterator it(QMPlay2Core.getSettingsDir() + "profiles/", QStringList() << "QMPlay2.ini", QDir::Files, QDirIterator::Subdirectories);
+	while (it.hasNext())
+	{
+		const QString path = it.next();
+		const int right = QMPlay2Core.getSettingsDir().length() + strlen("profiles/");
+		const int left = strlen("/QMPlay2.ini");
+		const QString profile = path.mid(right, path.length() - right - left);
+		profiles << profile;
+	}
+	return profiles;
 }

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -29,6 +29,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QUrl>
+#include <QMessageBox>
 
 #include <math.h>
 
@@ -167,6 +168,25 @@ QString Functions::fileExt(const QString &f)
 	if (idx > -1)
 		return f.mid(idx+1);
 	return QString();
+}
+bool Functions::dirRemoveRecursively(const QString &dirName)
+{
+#if QT_VERSION >= 0x050000
+	return QDir(dirName).removeRecursively();
+#else
+	QDir dir(dirName);
+	if (dir.exists(dirName))
+	{
+		foreach (const QFileInfo &info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
+		{
+			const QString &path = info.absoluteFilePath();
+			if (!(info.isDir() ? dirRemoveRecursively(path) : QFile::remove(path)))
+				return false;
+		}
+		return dir.rmdir(dirName);
+	}
+	return true;
+#endif
 }
 
 QString Functions::cleanPath(QString p)
@@ -618,11 +638,11 @@ QStringList Functions::getProfiles()
 {
 	QStringList profiles;
 
-	QDirIterator it(QMPlay2Core.getSettingsDir() + "profiles/", QStringList() << "QMPlay2.ini", QDir::Files, QDirIterator::Subdirectories);
+	QDirIterator it(QMPlay2Core.getSettingsDir() + "Profiles/", QStringList() << "QMPlay2.ini", QDir::Files, QDirIterator::Subdirectories);
 	while (it.hasNext())
 	{
 		const QString path = it.next();
-		const int right = QMPlay2Core.getSettingsDir().length() + strlen("profiles/");
+		const int right = QMPlay2Core.getSettingsDir().length() + strlen("Profiles/");
 		const int left = strlen("/QMPlay2.ini");
 		const QString profile = path.mid(right, path.length() - right - left);
 		profiles << profile;

--- a/src/qmplay2/Functions.cpp
+++ b/src/qmplay2/Functions.cpp
@@ -27,7 +27,6 @@
 #include <QMimeData>
 #include <QPainter>
 #include <QDir>
-#include <QDirIterator>
 #include <QUrl>
 #include <QMessageBox>
 
@@ -168,25 +167,6 @@ QString Functions::fileExt(const QString &f)
 	if (idx > -1)
 		return f.mid(idx+1);
 	return QString();
-}
-bool Functions::dirRemoveRecursively(const QString &dirName)
-{
-#if QT_VERSION >= 0x050000
-	return QDir(dirName).removeRecursively();
-#else
-	QDir dir(dirName);
-	if (dir.exists(dirName))
-	{
-		foreach (const QFileInfo &info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst))
-		{
-			const QString &path = info.absoluteFilePath();
-			if (!(info.isDir() ? dirRemoveRecursively(path) : QFile::remove(path)))
-				return false;
-		}
-		return dir.rmdir(dirName);
-	}
-	return true;
-#endif
 }
 
 QString Functions::cleanPath(QString p)
@@ -632,20 +612,4 @@ bool Functions::wrapMouse(QWidget *widget, QPoint &mousePos, int margin)
 		QCursor::setPos(widget->mapToGlobal(mousePos));
 
 	return doWrap;
-}
-
-QStringList Functions::getProfiles()
-{
-	QStringList profiles;
-
-	QDirIterator it(QMPlay2Core.getSettingsDir() + "Profiles/", QStringList() << "QMPlay2.ini", QDir::Files, QDirIterator::Subdirectories);
-	while (it.hasNext())
-	{
-		const QString path = it.next();
-		const int right = QMPlay2Core.getSettingsDir().length() + strlen("Profiles/");
-		const int left = strlen("/QMPlay2.ini");
-		const QString profile = path.mid(right, path.length() - right - left);
-		profiles << profile;
-	}
-	return profiles;
 }

--- a/src/qmplay2/QMPlay2Core.cpp
+++ b/src/qmplay2/QMPlay2Core.cpp
@@ -144,6 +144,18 @@ void QMPlay2CoreClass::init(bool loadModules, bool modulesInSubdirs, const QStri
 		settingsDir = Functions::cleanPath(settingsPath);
 	QDir(settingsDir).mkpath(".");
 
+	{
+		QSettings profileSettings(settingsDir + "Profile.ini", QSettings::IniFormat);
+		settingsProfile = profileSettings.value("Profile", "/").toString();
+		if(settingsProfile != "/")
+		{
+			settingsProfile.prepend("profiles/");
+			QDir(settingsDir).mkpath(settingsProfile);
+		}
+		if(!settingsProfile.endsWith('/'))
+			settingsProfile.append('/');
+	}
+
 	logFilePath = settingsDir + "QMPlay2.log";
 
 	/* Rename config file */
@@ -163,7 +175,7 @@ void QMPlay2CoreClass::init(bool loadModules, bool modulesInSubdirs, const QStri
 	setLanguage();
 
 #ifdef Q_OS_WIN
-	timeBeginPeriod(1); //ustawianie rozdzielczości timera na 1ms (dla Sleep())
+	timeBeginPeriod(1); //Set the timer for 1ms resolution (for Sleep ())
 #endif
 
 #ifndef QT_DEBUG

--- a/src/qmplay2/QMPlay2Core.cpp
+++ b/src/qmplay2/QMPlay2Core.cpp
@@ -149,7 +149,7 @@ void QMPlay2CoreClass::init(bool loadModules, bool modulesInSubdirs, const QStri
 		settingsProfile = profileSettings.value("Profile", "/").toString();
 		if (settingsProfile != "/")
 		{
-			settingsProfile.prepend("profiles/");
+			settingsProfile.prepend("Profiles/");
 			QDir(settingsDir).mkpath(settingsProfile);
 		}
 		if (!settingsProfile.endsWith('/'))

--- a/src/qmplay2/QMPlay2Core.cpp
+++ b/src/qmplay2/QMPlay2Core.cpp
@@ -147,12 +147,12 @@ void QMPlay2CoreClass::init(bool loadModules, bool modulesInSubdirs, const QStri
 	{
 		QSettings profileSettings(settingsDir + "Profile.ini", QSettings::IniFormat);
 		settingsProfile = profileSettings.value("Profile", "/").toString();
-		if(settingsProfile != "/")
+		if (settingsProfile != "/")
 		{
 			settingsProfile.prepend("profiles/");
 			QDir(settingsDir).mkpath(settingsProfile);
 		}
-		if(!settingsProfile.endsWith('/'))
+		if (!settingsProfile.endsWith('/'))
 			settingsProfile.append('/');
 	}
 

--- a/src/qmplay2/Settings.cpp
+++ b/src/qmplay2/Settings.cpp
@@ -19,7 +19,7 @@
 #include <Settings.hpp>
 
 Settings::Settings(const QString &name) :
-	QSettings(QMPlay2Core.getSettingsDir() + name + ".ini", QSettings::IniFormat)
+	QSettings(QMPlay2Core.getSettingsDir() + QMPlay2Core.getSettingsProfile() + name + ".ini", QSettings::IniFormat)
 {}
 Settings::~Settings()
 {

--- a/src/qmplay2/headers/Functions.hpp
+++ b/src/qmplay2/headers/Functions.hpp
@@ -141,6 +141,8 @@ namespace Functions
 	quint32 getBestSampleRate();
 
 	bool wrapMouse(QWidget *widget, QPoint &mousePos, int margin = 0);
+
+	QStringList getProfiles();
 }
 
 #endif

--- a/src/qmplay2/headers/Functions.hpp
+++ b/src/qmplay2/headers/Functions.hpp
@@ -69,6 +69,7 @@ namespace Functions
 	QString filePath(const QString &);
 	QString fileName(QString, bool extension = true);
 	QString fileExt(const QString &);
+	bool dirRemoveRecursively(const QString &dirName);
 
 	QString cleanPath(QString);
 	QString cleanFileName(QString);

--- a/src/qmplay2/headers/Functions.hpp
+++ b/src/qmplay2/headers/Functions.hpp
@@ -69,7 +69,6 @@ namespace Functions
 	QString filePath(const QString &);
 	QString fileName(QString, bool extension = true);
 	QString fileExt(const QString &);
-	bool dirRemoveRecursively(const QString &dirName);
 
 	QString cleanPath(QString);
 	QString cleanFileName(QString);
@@ -142,8 +141,6 @@ namespace Functions
 	quint32 getBestSampleRate();
 
 	bool wrapMouse(QWidget *widget, QPoint &mousePos, int margin = 0);
-
-	QStringList getProfiles();
 }
 
 #endif

--- a/src/qmplay2/headers/QMPlay2Core.hpp
+++ b/src/qmplay2/headers/QMPlay2Core.hpp
@@ -68,7 +68,7 @@ public:
 
 	inline QString getSettingsDir()
 	{
-		return settingsDir;
+		return settingsDir + settingsProfile;
 	}
 	inline QString getShareDir()
 	{
@@ -180,7 +180,7 @@ private:
 
 	QVector<Module *> pluginsInstance;
 	QTranslator *translator, *qtTranslator;
-	QString shareDir, langDir, settingsDir, logFilePath;
+	QString shareDir, langDir, settingsDir, logFilePath, settingsProfile;
 	QAtomicInt working;
 	QStringList logs;
 	QMap<QString, QString> languages;

--- a/src/qmplay2/headers/QMPlay2Core.hpp
+++ b/src/qmplay2/headers/QMPlay2Core.hpp
@@ -68,7 +68,11 @@ public:
 
 	inline QString getSettingsDir()
 	{
-		return settingsDir + settingsProfile;
+		return settingsDir;
+	}
+	inline QString getSettingsProfile()
+	{
+		return settingsProfile;
 	}
 	inline QString getShareDir()
 	{


### PR DESCRIPTION
The feature implemented in this pull request is changing profiles (settings group). For example, to have a profile for videos (like the placement of docks, equalizer) and another one for music files.

In the background it is implemented using sub directories in side `~/.qmplay/profiles/` (or the default one). There is full backward compatibility (the old settings is called default).

As always, please check the code style, tr function use (maybe I missed somewhere) and that it works on your systems.