### PR TITLE
Add Skip & Stop After track

### DIFF
--- a/src/gui/MainWidget.cpp
+++ b/src/gui/MainWidget.cpp
@@ -702,6 +702,8 @@ void MainWidget::createMenuBar()
 	connect(menuBar->playlist->expandAll, SIGNAL(triggered()), playlistDock, SLOT(expandAll()));
 	connect(menuBar->playlist->goToPlayback, SIGNAL(triggered()), playlistDock, SLOT(goToPlayback()));
 	connect(menuBar->playlist->queue, SIGNAL(triggered()), playlistDock, SLOT(queue()));
+	connect(menuBar->playlist->skip, SIGNAL(triggered()), playlistDock, SLOT(skip()));
+	connect(menuBar->playlist->stopAfter, SIGNAL(triggered()), playlistDock, SLOT(stopAfter()));
 	connect(menuBar->playlist->entryProperties, SIGNAL(triggered()), playlistDock, SLOT(entryProperties()));
 
 	connect(menuBar->player->togglePlay, SIGNAL(triggered()), this, SLOT(togglePlay()));

--- a/src/gui/MenuBar.cpp
+++ b/src/gui/MenuBar.cpp
@@ -155,6 +155,8 @@ MenuBar::Playlist::Playlist(MenuBar *parent) :
 	newAction(Playlist::tr("&Go to the playback"), this, goToPlayback, false, QIcon(), false);
 	addSeparator();
 	newAction(Playlist::tr("&Enqueue"), this, queue, false, QIcon(), false);
+	newAction(Player::tr("&Skip"), this, skip, true, QIcon(), false);
+	newAction(Player::tr("&Stop after this track"), this, stopAfter, true, QIcon(), false);
 	addSeparator();
 	newAction(Playlist::tr("&Properties"), this, entryProperties, false, QMPlay2Core.getIconFromTheme("document-properties"), false);
 }
@@ -458,6 +460,8 @@ void MenuBar::setKeyShortcuts()
 	shortcuts->appendAction(playlist->expandAll, "KeyBindings/Playlist-expandAll", "");
 	shortcuts->appendAction(playlist->goToPlayback, "KeyBindings/Playlist-goToPlayback", "Ctrl+P");
 	shortcuts->appendAction(playlist->queue, "KeyBindings/Playlist-queue", "Q");
+	shortcuts->appendAction(playlist->skip, "KeyBindings/Playlist-skip", "");
+	shortcuts->appendAction(playlist->stopAfter, "KeyBindings/Playlist-stopAfter", "");
 	shortcuts->appendAction(playlist->entryProperties, "KeyBindings/Playlist-entryProperties", "Alt+Return");
 
 	shortcuts->appendAction(playlist->add->file, "KeyBindings/Playlist-Add-file", "Ctrl+I");

--- a/src/gui/MenuBar.hpp
+++ b/src/gui/MenuBar.hpp
@@ -72,7 +72,7 @@ public:
 		Add *add;
 		QMenu *extensions;
 		Sort *sort;
-		QAction *stopLoading, *sync, *loadPlist, *savePlist, *saveGroup, *delEntries, *delNonGroupEntries, *clear, *copy, *paste, *newGroup, *renameGroup, *find, *collapseAll, *expandAll, *goToPlayback, *queue, *entryProperties;
+		QAction *stopLoading, *sync, *loadPlist, *savePlist, *saveGroup, *delEntries, *delNonGroupEntries, *clear, *copy, *paste, *newGroup, *renameGroup, *find, *collapseAll, *expandAll, *goToPlayback, *queue, *skip, *stopAfter, *entryProperties;
 	};
 
 	class Player : public QMenu

--- a/src/gui/PlaylistDock.hpp
+++ b/src/gui/PlaylistDock.hpp
@@ -71,6 +71,8 @@ public slots:
 	void stopLoading();
 	void next(bool playingError = false);
 	void prev();
+	void skip();
+	void stopAfter();
 	void start();
 	void clearCurrentPlaying();
 	void setCurrentPlaying();

--- a/src/gui/PlaylistWidget.cpp
+++ b/src/gui/PlaylistWidget.cpp
@@ -430,7 +430,7 @@ QTreeWidgetItem *AddThr::insertPlaylistEntries(const Playlist::Entries &entries,
 			if (!firstItem)
 				firstItem = currentItem;
 		}
-		if (entry.selected)
+		if (entry.flags & Playlist::Entry::FlagSelected)
 			firstItem = entry.GID ? groupList.last() : currentItem;
 	}
 	return firstItem;
@@ -660,8 +660,18 @@ QTreeWidgetItem *PlaylistWidget::newEntry(const Playlist::Entry &entry, QTreeWid
 	setEntryIcon(img, tWI);
 
 	tWI->setFlags(tWI->flags() &~ Qt::ItemIsDropEnabled);
+	if (entry.flags & (Playlist::Entry::FlagSkip | Playlist::Entry::FlagStopAfter))
+	{
+		QFont font = tWI->font(0);
+		if (entry.flags & Playlist::Entry::FlagSkip)
+			font.setStrikeOut(true);
+		if (entry.flags & Playlist::Entry::FlagStopAfter)
+			font.setItalic(true);
+		tWI->setFont(0, font);
+	}
 	tWI->setText(0, entry.name);
 	tWI->setData(0, Qt::UserRole, entry.url);
+	tWI->setData(0, Qt::UserRole + 1, entry.flags & (Playlist::Entry::FlagSkip | Playlist::Entry::FlagStopAfter)); //store only those flags
 	tWI->setText(2, Functions::timeToStr(entry.length));
 	tWI->setData(2, Qt::UserRole, entry.length);
 

--- a/src/modules/Playlists/PLS.cpp
+++ b/src/modules/Playlists/PLS.cpp
@@ -108,7 +108,9 @@ Playlist::Entries PLS::read()
 		else if (key == "QMPlay_length")
 			entry.length = value.toDouble();
 		else if (key == "QMPlay_sel")
-			entry.selected = value.toInt();
+			entry.flags |= Entry::FlagSelected;
+		else if (key == "QMPlay_flags")
+			entry.flags = value.toInt();
 		else if (key == "QMPlay_queue")
 			entry.queue = value.toInt();
 		else if (key == "QMPlay_GID")
@@ -147,8 +149,8 @@ bool PLS::write(const Entries &list)
 			writer->write(QString("Length" + idx + "=" + QString::number((qint32)(entry.length + 0.5)) + "\r\n").toUtf8());
 			writer->write(QString("QMPlay_length" + idx + "=" + QString::number(entry.length, 'g', 13) + "\r\n").toUtf8());
 		}
-		if (entry.selected)
-			writer->write(QString("QMPlay_sel" + idx + "=" + QString::number(entry.selected) + "\r\n").toUtf8());
+		if (entry.flags)
+			writer->write(QString("QMPlay_flags" + idx + "=" + QString::number(entry.flags) + "\r\n").toUtf8());
 		if (entry.queue)
 			writer->write(QString("QMPlay_queue" + idx + "=" + QString::number(entry.queue) + "\r\n").toUtf8());
 		if (entry.GID)

--- a/src/qmplay2/headers/Playlist.hpp
+++ b/src/qmplay2/headers/Playlist.hpp
@@ -30,16 +30,21 @@ public:
 	class Entry
 	{
 	public:
+		enum Flags
+		{
+			FlagSelected = 0x1,
+			FlagSkip = 0x2,
+			FlagStopAfter = 0x4
+		};
+
 		inline Entry() :
 			length(-1.0),
-			selected(false),
-			queue(0), GID(0), parent(0)
+			flags(0), queue(0), GID(0), parent(0)
 		{}
 
 		QString name, url;
 		double length;
-		bool selected;
-		qint32 queue, GID, parent;
+		qint32 flags, queue, GID, parent;
 	};
 	typedef QVector<Entry> Entries;
 


### PR DESCRIPTION
This pull request adds "skip track" and "stop after track" to playlist.

Those flags are saved using OR between flags and saving the flags as int instead of selected (in PLS: newer version reads without problem old format, while older version reads newer format without selected field).

Skip track makes, that when the playlist automagically moves to the skipped track, it moves to the next one. Shown using strike through the title text.

Stop after track is to stop when the selected track finishes playing, if the flag is set then it just stops the play. Shown using the "stop" string near the time.

Please say your thoughts about the way it is shown to the user.