### PR TITLE
Change menu's separator color to border's color

### DIFF
--- a/src/gui/Appearance.hpp
+++ b/src/gui/Appearance.hpp
@@ -35,7 +35,6 @@ class Appearance : public QDialog
 	Q_OBJECT
 public:
 	static void init();
-	static void applyPalette(const QPalette &pal, const QPalette &sliderButton_pal, const QPalette &mainW_pal);
 
 	Appearance(QWidget *p);
 private slots:


### PR DESCRIPTION
This small pull request changes menu's separator color to be the same as border's color. For example during QMPlay2 dark theme, the separator wasn't seen at all.

What are your thoughts to adding a multiline text box in the bottom of appearance dialog for setting the stylesheet of the app (good for advanced users)?