### PR TITLE
fix deprecated cmake function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,6 @@ if(NOT SVG_MODULE_FOUND)
     endif()
 endif()
 
-PRINT_ENABLED_FEATURES()
-PRINT_DISABLED_FEATURES()
+feature_summary(WHAT ENABLED_FEATURES DESCRIPTION "Enabled features:")
+feature_summary(WHAT DISABLED_FEATURES DESCRIPTION "Disabled features:")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
PRINT_ENABLED_FEATURES and PRINT_DISABLED_FEATURES are deprecated since CMake 3.8.
- Checked using CMake 2.8