### PR TITLE
use QByteArray::constData() instead of QByteArray::data()

### DIFF
--- a/src/modules/Inputs/PCM.cpp
+++ b/src/modules/Inputs/PCM.cpp
@@ -91,7 +91,7 @@ bool PCM::read(Packet &decoded, int &idx)
 	const int samples_with_channels = dataBA.size() / bytes[fmt];
 	decoded.resize(samples_with_channels * sizeof(float));
 	float *decoded_data = (float *)decoded.data();
-	ByteArray data(dataBA.data(), dataBA.size(), bigEndian);
+	ByteArray data(dataBA.constData(), dataBA.size(), bigEndian);
 	switch (fmt)
 	{
 		case PCM_U8:

--- a/src/modules/PulseAudio/Pulse.cpp
+++ b/src/modules/PulseAudio/Pulse.cpp
@@ -130,7 +130,7 @@ bool Pulse::write(const QByteArray &arr, bool &showError)
 {
 	int error = 0;
 	writing = true;
-	const bool ret = pa_simple_write(pulse, arr.data(), arr.size(), &error) >= 0;
+	const bool ret = pa_simple_write(pulse, arr.constData(), arr.size(), &error) >= 0;
 	writing = false;
 	if (error == PA_ERR_KILLED)
 		showError = false;

--- a/src/modules/Subtitles/Classic.cpp
+++ b/src/modules/Subtitles/Classic.cpp
@@ -116,7 +116,7 @@ bool Classic::toASS(const QByteArray &txt, LibASS *ass, double fps)
 		if ((idx = line.indexOf(TMPRegExp)) > -1)
 		{
 			int h = -1, m = -1, s = -1;
-			sscanf(line.toLatin1().data() + idx, "%d:%d:%d", &h, &m, &s);
+			sscanf(line.toLatin1().constData() + idx, "%d:%d:%d", &h, &m, &s);
 			if (h > -1 && m > -1 && s > -1)
 			{
 				start = h*3600 + m*60 + s;
@@ -126,7 +126,7 @@ bool Classic::toASS(const QByteArray &txt, LibASS *ass, double fps)
 		else if ((idx = line.indexOf(MPL2RegExp)) > -1)
 		{
 			int s = -1, e = -1;
-			sscanf(line.toLatin1().data() + idx, "[%d][%d]", &s, &e);
+			sscanf(line.toLatin1().constData() + idx, "[%d][%d]", &s, &e);
 			if (s > -1)
 			{
 				for (const QString &l : convertLine(MPL2RegExp, line).split('\n'))
@@ -158,7 +158,7 @@ bool Classic::toASS(const QByteArray &txt, LibASS *ass, double fps)
 		else if ((idx = line.indexOf(MicroDVDRegExp)) > -1)
 		{
 			int s = -1, e = -1;
-			sscanf(line.toLatin1().data() + idx, "{%d}{%d}", &s, &e);
+			sscanf(line.toLatin1().constData() + idx, "{%d}{%d}", &s, &e);
 			if (s > -1)
 			{
 				sub = convertLine(MicroDVDRegExp, line);

--- a/src/modules/Subtitles/SRT.cpp
+++ b/src/modules/Subtitles/SRT.cpp
@@ -45,7 +45,7 @@ bool SRT::toASS(const QByteArray &srt, LibASS *ass, double)
 				for (int i = 0; i < 2; ++i)
 				{
 					int h = -1, m = -1, s = -1, ms = -1;
-					sscanf(time[i].toLatin1().data(), scanfFmt, &h, &m, &s, &ms);
+					sscanf(time[i].toLatin1().constData(), scanfFmt, &h, &m, &s, &ms);
 					if (h > -1 && m > -1 && s > -1 && ms > -1)
 						time_double[i] = h*3600 + m*60 + s + ms/1000.0;
 					else

--- a/src/modules/Visualizations/FFTSpectrum.cpp
+++ b/src/modules/Visualizations/FFTSpectrum.cpp
@@ -215,7 +215,7 @@ void FFTSpectrum::sendSoundData(const QByteArray &data)
 		const int size = qMin((data.size() - newDataPos) / (int)sizeof(float), (tmpDataSize - tmpDataPos) * w.chn);
 		if (!size)
 			break;
-		fltmix(tmpData + tmpDataPos, (const float *)(data.data() + newDataPos), size, w.chn);
+		fltmix(tmpData + tmpDataPos, (const float *)(data.constData() + newDataPos), size, w.chn);
 		newDataPos += size * sizeof(float);
 		tmpDataPos += size / w.chn;
 		if (tmpDataPos == tmpDataSize)

--- a/src/modules/Visualizations/SimpleVis.cpp
+++ b/src/modules/Visualizations/SimpleVis.cpp
@@ -238,7 +238,7 @@ void SimpleVis::sendSoundData(const QByteArray &data)
 	while (newDataPos < data.size())
 	{
 		const int size = qMin(data.size() - newDataPos, tmpData.size() - tmpDataPos);
-		fltcpy((float *)(tmpData.data() + tmpDataPos), (const float *)(data.data() + newDataPos), size);
+		fltcpy((float *)(tmpData.data() + tmpDataPos), (const float *)(data.constData() + newDataPos), size);
 		newDataPos += size;
 		tmpDataPos += size;
 		if (tmpDataPos == tmpData.size())

--- a/src/qmplay2/SndResampler.cpp
+++ b/src/qmplay2/SndResampler.cpp
@@ -100,7 +100,7 @@ void SndResampler::convert(const QByteArray &src, QByteArray &dst)
 
 	dst.reserve(out_size * sizeof(float) * dst_channels);
 
-	quint8 *in[]  = {(quint8 *)src.data()};
+	quint8 *in[]  = {(quint8 *)src.constData()};
 	quint8 *out[] = {(quint8 *)dst.data()};
 
 #ifdef QMPLAY2_AVRESAMPLE


### PR DESCRIPTION
Common practice for read-only access; the Qt documentation claims this is (can be) faster because no data is ever (deep) copied.
The patch modifies the locations where the potential gain should be the most beneficial.
There is 1 other location PortAudioWriter::writeStream(); that hunk intersects with another patch I plan to propose and will thus be part of the corresponding PR (which doesn't mean it cannot be submitted along with these changes).
