### PR TITLE
CMake: Append SKIP_AUTOMOC property for autogenerated headers

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -97,6 +97,7 @@ if(APPLE)
 endif()
 
 qt5_wrap_ui(GUI_FORM_HDR ${GUI_FORMS})
+set_property(SOURCE ${GUI_FORM_HDR} PROPERTY SKIP_AUTOMOC ON)
 
 include_directories(../qmplay2/headers)
 

--- a/src/modules/Extensions/CMakeLists.txt
+++ b/src/modules/Extensions/CMakeLists.txt
@@ -66,6 +66,7 @@ if(USE_DATMUSIC OR USE_ANIMEODCINKI OR USE_WBIJAM)
 endif()
 
 qt5_wrap_ui(Extensions_FORM_HDR ${Extensions_FORMS})
+set_property(SOURCE ${Extensions_FORM_HDR} PROPERTY SKIP_AUTOMOC ON)
 
 include_directories(../../qmplay2/headers)
 


### PR DESCRIPTION
For supress policy CMP0071 related warnings with >=cmake-3.10.1.
Issue: https://github.com/zaps166/QMPlay2/issues/132