### PR TITLE
Fix build with older Qt and VA versions

### DIFF
--- a/src/modules/FFmpeg/FFDecVAAPI.cpp
+++ b/src/modules/FFmpeg/FFDecVAAPI.cpp
@@ -59,7 +59,7 @@ public:
 
     bool init(quint32 *textures) override
     {
-        static bool isEGL = (qgetenv("QT_XCB_GL_INTEGRATION").compare("xcb_egl", Qt::CaseInsensitive) == 0);
+        static bool isEGL = (QString(qgetenv("QT_XCB_GL_INTEGRATION")).compare("xcb_egl", Qt::CaseInsensitive) == 0);
         if (isEGL)
             return false; // Not supported
         return (vaCreateSurfaceGLX(m_vaapi->VADisp, GL_TEXTURE_2D, *textures, &m_glSurface) == VA_STATUS_SUCCESS);

--- a/src/modules/FFmpeg/VAAPI.cpp
+++ b/src/modules/FFmpeg/VAAPI.cpp
@@ -175,7 +175,9 @@ void VAAPI::maybeInitVPP(int surfaceW, int surfaceH)
                                 VAProcFilterDeinterlacing,
                                 vpp_deint_type,
                                 0,
+#if VA_MAJOR_VERSION >= 1
                                 {}
+#endif
                             };
                             if (vaCreateBuffer(VADisp, context_vpp, VAProcFilterParameterBufferType, sizeof deint_params, 1, &deint_params, &m_vppDeintBuff) != VA_STATUS_SUCCESS)
                                 m_vppDeintBuff = VA_INVALID_ID;


### PR DESCRIPTION
- QByteArray::compare() is Qt 5.12
- The "reserved" fields in VAProcFilterParameterBufferDeinterlacing and other structs
  were introduced in VA 1.0.0 only.

Tested with Qt 5.9.7 and VA 0.40.0
