### PR TITLE
Remove unused preprocessor directives in MediaBrowser.cpp

### DIFF
--- a/src/modules/Extensions/MediaBrowser.cpp
+++ b/src/modules/Extensions/MediaBrowser.cpp
@@ -50,10 +50,6 @@
 
 #include <algorithm>
 
-#include <libavutil/cpu.h>
-#ifdef QMPLAY2_CPU_X86_32
-#endif
-
 Q_LOGGING_CATEGORY(mb, "MediaBrowser")
 
 constexpr const char *g_mediaBrowserBaseUrl = "https://raw.githubusercontent.com/zaps166/QMPlay2OnlineContents/master/";


### PR DESCRIPTION
The unused libavutil header breaks the build in case libavutil headers are not installed in a standard location.

By the way, I'm currently trying to build this under Tumbleweed because the official package crashes on startup. Maybe the recently enabled LTO causes problems.