### PR TITLE
Fix openSUSE installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,23 @@ Table of Contents
 - Install AUR client (e.g. yay),
 - run the following command: `yay -S qmplay2`
 
-#### Easy installation on openSUSE Leap 15.1
-
+#### Easy installation on openSUSE
+##### For openSUSE Leap 15.1:
 - Run the following commands:
 ```
 $ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.1 Packman
+$ suod zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
+$ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.1
+$ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
 $ sudo zypper in QMPlay2
 ```
-- QMPlay2 from openSUSE repositories might lack some features.
-- Don't use official package, because it is obsolete.
+##### For openSUSE Tumbleweed:
+- Run the following commands:
+```
+$ sudo zypper ar http://packman.inode.at/suse/openSUSE_Tumbleweed Packman
+$ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Tumbleweed
+$ sudo zypper in QMPlay2
+```
 - Don't mix FFmpeg from different repositories!
 
 #### Easy installation on Gentoo Linux


### PR DESCRIPTION
The current installation instructions for openSUSE are a bit outdated:
 * QMPlay2 is no longer in the Packman repositories for Leap 15.1/Tumbleweed
 * The QMPlay2 version from the official repos is working just fine as long as you are using the codecs from packman
 * Running the suggested commands on openSUSE Leap 15.1 will therefore give you version 18.04.1, you need to add the multimedia:apps repository to get the latest version for leap
 * Packman codecs must be manually installed, I added some commands to make this happen