### PR TITLE
Update README.md: change installation method for gentoo users

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ sudo zypper in QMPlay2
 
 #### Easy installation on Gentoo Linux
 
-[Gentoo Linux repository](https://github.com/reagentoo/gentoo-overlay/tree/master/media-video/qmplay2)
+- Run the following command: `emerge --ask media-video/qmplay2`
 
 ## YouTube
 


### PR DESCRIPTION
[the latest version](https://github.com/zaps166/QMPlay2/releases/tag/19.12.19) has been added to the Gentoo tree and now it simplified the installation method using `emerge` command only

more: https://github.com/gentoo/gentoo/pull/11268