### PR TITLE
Fix build on Qt 5.15, OpenMandriva patch

### DIFF
--- a/src/modules/AudioFilters/EqualizerGUI.cpp
+++ b/src/modules/AudioFilters/EqualizerGUI.cpp
@@ -25,6 +25,7 @@
 #include <QLabel>
 #include <QSlider>
 #include <QPainter>
+#include <QPainterPath>
 #include <QCheckBox>
 #include <QScrollArea>
 #include <QGridLayout>

--- a/src/modules/Visualizations/FFTSpectrum.cpp
+++ b/src/modules/Visualizations/FFTSpectrum.cpp
@@ -20,6 +20,7 @@
 #include <Functions.hpp>
 
 #include <QPainter>
+#include <QPainterPath>
 #include <qevent.h>
 
 extern "C"

--- a/src/modules/Visualizations/SimpleVis.cpp
+++ b/src/modules/Visualizations/SimpleVis.cpp
@@ -20,6 +20,7 @@
 #include <Functions.hpp>
 
 #include <QPainter>
+#include <QPainterPath>
 
 #include <cmath>
 


### PR DESCRIPTION
To build QMPlay2 on Qt 5.15 is needed to add missing include <QPainterPath> to few files.
Since Qt 5.15, to optimize compiling, developers decided stop the automatic addition QPainterPath to includes.

I create this patch for my OpenMandriva Cooker and this fix build with new Qt 5.15 and Clang 10. https://github.com/OpenMandrivaAssociation/qmplay2/commit/9dbc9787b486b13f18fac8f89049d79aaf8ee0a0#diff-07d1c74ae5c147e34d32d94d231913d9
