### PR TITLE
Update installation instructions for openSUSE, add installation instructions for Fedora using RPMFusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Table of Contents
 - run the following command: `yay -S qmplay2`
 
 #### Easy installation on openSUSE
+- Don't mix FFmpeg from different repositories!
 ##### For openSUSE Leap 15.2:
-- Run the following commands:
+<details>
+<summary>Run the following commands:</summary>
+
 ```
 $ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.2 Packman
 $ sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
@@ -45,8 +48,12 @@ $ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/open
 $ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
 $ sudo zypper in QMPlay2
 ```
+</details>
+
 ##### For openSUSE Leap 15.1:
-- Run the following commands:
+<details>
+<summary>Run the following commands:</summary>
+
 ```
 $ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.1 Packman
 $ sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
@@ -54,14 +61,18 @@ $ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/open
 $ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
 $ sudo zypper in QMPlay2
 ```
+</details>
+
 ##### For openSUSE Tumbleweed:
-- Run the following commands:
+<details>
+<summary>Run the following commands:</summary>
+
 ```
 $ sudo zypper ar http://packman.inode.at/suse/openSUSE_Tumbleweed Packman
 $ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Tumbleweed
 $ sudo zypper in QMPlay2
 ```
-- Don't mix FFmpeg from different repositories!
+</details>
 
 #### Easy installation on Gentoo Linux
 

--- a/README.md
+++ b/README.md
@@ -37,42 +37,23 @@ Table of Contents
 
 #### Easy installation on openSUSE
 - Don't mix FFmpeg from different repositories!
-##### For openSUSE Leap 15.2:
-<details>
-<summary>Run the following commands:</summary>
-
-```
-$ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.2 Packman
-$ sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
-$ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.2
-$ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
-$ sudo zypper in QMPlay2
-```
-</details>
-
-##### For openSUSE Leap 15.1:
-<details>
-<summary>Run the following commands:</summary>
-
-```
-$ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.1 Packman
-$ sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
-$ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.1
-$ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
-$ sudo zypper in QMPlay2
-```
-</details>
-
-##### For openSUSE Tumbleweed:
-<details>
-<summary>Run the following commands:</summary>
-
-```
-$ sudo zypper ar http://packman.inode.at/suse/openSUSE_Tumbleweed Packman
-$ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Tumbleweed
-$ sudo zypper in QMPlay2
-```
-</details>
+- Run the following commands:<br><details><summary>openSUSE Leap 15.2</summary><pre>
+sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.2 Packman
+sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
+sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.2
+sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
+sudo zypper in QMPlay2
+</pre></details><details><summary>openSUSE Leap 15.1</summary><pre>
+sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.1 Packman
+sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
+sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.1
+sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
+sudo zypper in QMPlay2
+</pre></details><details><summary>openSUSE Tumbleweed</summary><pre>
+sudo zypper ar http://packman.inode.at/suse/openSUSE_Tumbleweed Packman
+sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Tumbleweed
+sudo zypper in QMPlay2
+</pre></details>
 
 #### Easy installation on Gentoo Linux
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,20 @@ Table of Contents
 - run the following command: `yay -S qmplay2`
 
 #### Easy installation on openSUSE
+##### For openSUSE Leap 15.2:
+- Run the following commands:
+```
+$ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.2 Packman
+$ sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
+$ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.2
+$ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
+$ sudo zypper in QMPlay2
+```
 ##### For openSUSE Leap 15.1:
 - Run the following commands:
 ```
 $ sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.1 Packman
-$ suod zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
+$ sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
 $ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.1
 $ sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
 $ sudo zypper in QMPlay2

--- a/README.md
+++ b/README.md
@@ -37,47 +37,31 @@ Table of Contents
 
 #### Easy installation on openSUSE
 - Don't mix FFmpeg from different repositories!
-- Run the following commands:<br><details><summary>openSUSE Leap 15.2</summary><pre>
+- Run the following commands:
+##### openSUSE Leap 15.2
+```
 sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.2 Packman
 sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
 sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.2
 sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
 sudo zypper in QMPlay2
-</pre></details><details><summary>openSUSE Leap 15.1</summary><pre>
-sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.1 Packman
-sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
-sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.1
-sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.1
-sudo zypper in QMPlay2
-</pre></details><details><summary>openSUSE Tumbleweed</summary><pre>
+```
+##### openSUSE Tumbleweed
+```
 sudo zypper ar http://packman.inode.at/suse/openSUSE_Tumbleweed Packman
 sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Tumbleweed
 sudo zypper in QMPlay2
-</pre></details>
-
+```
 #### Easy installation on Fedora
-- Run the following commands:<br><details><summary>Fedora 32</summary><pre>
-sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-32.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-32.noarch.rpm
+- Run the following commands:
+```
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
 sudo dnf groupupdate core
 sudo dnf update
 sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
 sudo dnf groupupdate sound-and-video
 sudo dnf install qmplay2
-</pre></details><details><summary>Fedora 31</summary><pre>
-sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-31.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-31.noarch.rpm
-sudo dnf groupupdate core
-sudo dnf update
-sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
-sudo dnf groupupdate sound-and-video
-sudo dnf install qmplay2
-</pre></details><details><summary>Fedora Rawhide</summary><pre>
-sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-rawhide.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-rawhide.noarch.rpm
-sudo dnf groupupdate core
-sudo dnf update
-sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
-sudo dnf groupupdate sound-and-video
-sudo dnf install qmplay2
-</pre></details>
+```
 
 #### Easy installation on Gentoo Linux
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSU
 sudo zypper in QMPlay2
 </pre></details>
 
+#### Easy installation on Fedora
+- Run the following commands:<br><details><summary>Fedora 32</summary><pre>
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-32.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-32.noarch.rpm
+sudo dnf groupupdate core
+sudo dnf update
+sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
+sudo dnf groupupdate sound-and-video
+sudo dnf install qmplay2
+</pre></details><details><summary>Fedora 31</summary><pre>
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-31.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-31.noarch.rpm
+sudo dnf groupupdate core
+sudo dnf update
+sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
+sudo dnf groupupdate sound-and-video
+sudo dnf install qmplay2
+</pre></details><details><summary>Fedora Rawhide</summary><pre>
+sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-rawhide.noarch.rpm https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-rawhide.noarch.rpm
+sudo dnf groupupdate core
+sudo dnf update
+sudo dnf groupupdate multimedia --setop="install_weak_deps=False" --exclude=PackageKit-gstreamer-plugin
+sudo dnf groupupdate sound-and-video
+sudo dnf install qmplay2
+</pre></details>
+
 #### Easy installation on Gentoo Linux
 
 - Run the following command: `emerge --ask media-video/qmplay2`


### PR DESCRIPTION
So, I recently had some time so I thought it would be nice to polish the install instructions for openSUSE and update them for 15.2. I also added some instructions for Fedora 32, 31 and rawhide which use RPMFusion and include the installation of any necessary multimedia codecs.
I hope you like the new layout, any improvement suggestions are appreciated!