### PR TITLE
[Feature] Show related items in Youtube browser.

### DIFF
--- a/lang/de.ts
+++ b/lang/de.ts
@@ -2793,6 +2793,10 @@ QMPlay2 wird die Symbole nicht vergrößern!</translation>
         <source>Audio only</source>
         <translation>Nur Audio</translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation>Ähnliche anzeigen</translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/es.ts
+++ b/lang/es.ts
@@ -2794,6 +2794,10 @@ QMPlay2 will not scale up icons!</source>
         <source>Audio only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/fr.ts
+++ b/lang/fr.ts
@@ -2790,6 +2790,10 @@ QMPlay2 will not scale up icons!</source>
         <source>Audio only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/hu.ts
+++ b/lang/hu.ts
@@ -2794,6 +2794,10 @@ A QMPlay2 nem fogja az ikonokat méretezni!</translation>
         <source>Audio only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/ja.ts
+++ b/lang/ja.ts
@@ -2796,6 +2796,10 @@ QMPlay2はアイコンを拡大しません！</translation>
         <source>Audio only</source>
         <translation>オーディオのみ</translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/nl.ts
+++ b/lang/nl.ts
@@ -2,9 +2,27 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nl_NL">
 <context>
+    <name>ALSAWriter</name>
+    <message>
+        <source>Cannot open</source>
+        <translation type="unfinished">Het openen is mislukt</translation>
+    </message>
+    <message>
+        <source>back to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot open audio output stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AVThread</name>
     <message>
-        <location filename="src/gui/AVThread.cpp" line="102"/>
         <source>A/V thread has been incorrectly terminated!</source>
         <translation>Het A/V-proces is onjuist afgebroken!</translation>
     </message>
@@ -12,52 +30,42 @@
 <context>
     <name>AboutWidget</name>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="39"/>
         <source>About QMPlay2</source>
         <translation>Over QMPlay2</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="43"/>
         <source>video and audio player</source>
         <translation>video- en audiospeler</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="44"/>
         <source>Programmer</source>
         <translation>Ontwikkelaar</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="45"/>
         <source>Version</source>
         <translation>Versie</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="66"/>
         <source>Logs</source>
         <translation>Logboeken</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="75"/>
         <source>Change log</source>
         <translation>Wijzigingslog</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="84"/>
         <source>Contributors</source>
         <translation>Bijdragers</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="87"/>
         <source>Clear log</source>
         <translation>Logboek wissen</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="90"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="src/gui/AboutWidget.cpp" line="170"/>
         <source>Can&apos;t clear log</source>
         <translation>Het logboek kan niet worden gewist</translation>
     </message>
@@ -65,40 +73,52 @@
 <context>
     <name>Add</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="180"/>
         <source>&amp;Add</source>
         <translation>&amp;Toevoegen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="183"/>
         <source>&amp;Files</source>
         <translation>&amp;Bestanden</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="184"/>
         <source>&amp;Directory</source>
         <translation>&amp;Map</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="185"/>
         <source>&amp;Address</source>
         <translation>&amp;Adres</translation>
     </message>
 </context>
 <context>
+    <name>AddD</name>
+    <message>
+        <source>Tone generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation type="unfinished">Afspelen</translation>
+    </message>
+</context>
+<context>
     <name>AddressBox</name>
     <message>
-        <location filename="src/gui/AddressBox.cpp" line="32"/>
         <source>Autodetect address</source>
         <translation>Adres automatisch detecteren</translation>
     </message>
     <message>
-        <location filename="src/gui/AddressBox.cpp" line="33"/>
         <source>Direct address</source>
         <translation>Direct adres</translation>
     </message>
     <message>
-        <location filename="src/gui/AddressBox.cpp" line="90"/>
         <source>Additional module parameter</source>
         <translation>Aanvullende module-optie</translation>
     </message>
@@ -106,12 +126,10 @@
 <context>
     <name>AddressDialog</name>
     <message>
-        <location filename="src/gui/AddressDialog.cpp" line="30"/>
         <source>Add address</source>
         <translation>Adres toevoegen</translation>
     </message>
     <message>
-        <location filename="src/gui/AddressDialog.cpp" line="42"/>
         <source>Play</source>
         <translation>Afspelen</translation>
     </message>
@@ -119,159 +137,126 @@
 <context>
     <name>Appearance</name>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="225"/>
         <source>Appearance settings</source>
         <translation>Vormgeving</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="227"/>
         <source>Manage color schemes</source>
         <translation>Thema&apos;s beheren</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="232"/>
         <source>New</source>
         <translation>Nieuw</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="235"/>
         <source>Save</source>
         <translation>Opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="238"/>
         <source>Remove</source>
         <translation>Verwijderen</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="249"/>
         <source>Use custom colors</source>
         <translation>Eigen kleuren gebruiken</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="253"/>
         <source>Buttons color</source>
         <translation>Knopkleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="254"/>
         <source>Window color</source>
         <translation>Vensterkleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="255"/>
         <source>Border color</source>
         <translation>Randkleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="256"/>
         <source>Highlight color</source>
         <translation>Markeerkleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="257"/>
         <source>Base color</source>
         <translation>Basiskleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="258"/>
-        <location filename="src/gui/Appearance.cpp" line="269"/>
         <source>Text color</source>
         <translation>Tekstkleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="259"/>
         <source>Highlighted text color</source>
         <translation>Kleur van gemarkeerde tekst</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="260"/>
         <source>Slider button color</source>
         <translation>Schuifknopkleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="264"/>
         <source>Gradient in the video window</source>
         <translation>Kleurverloop op videovenster</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="267"/>
         <source>The color on the top and bottom</source>
         <translation>De bovenste en onderste kleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="268"/>
         <source>Color in the middle</source>
         <translation>De middelste kleur</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="272"/>
         <source>Wallpaper in the main window</source>
         <translation>Achtergrond van hoofdvenster</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="278"/>
         <source>Transparency</source>
         <translation>Doorzichtigheid</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="283"/>
         <source>Select wallpaper</source>
         <translation>Kies een achtergrond</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="388"/>
-        <location filename="src/gui/Appearance.cpp" line="394"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="388"/>
         <source>Enter the name for a color scheme</source>
         <translation>Geef het thema een naam</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="394"/>
         <source>The specified name already exists!</source>
         <translation>Deze naam is al in gebruik!</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="423"/>
         <source>Removing</source>
         <translation>Bezig met verwijderen…</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="423"/>
         <source>Do you want to remove</source>
         <translation>Wilt u het volgende verwijderen:</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="431"/>
         <source>Loading wallpaper</source>
         <translation>Bezig met laden van achtergrond…</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="431"/>
         <source>Pictures</source>
         <translation>Afbeeldingen</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="468"/>
         <source>Volatile settings</source>
         <translation>Snelle instellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="468"/>
         <source>is not writable, settings will be lost after restart. Consider creating a new color scheme!</source>
         <translation>is niet beschrijfbaar, dus de instellingen worden niet bewaard. Overweeg een nieuw thema te maken!</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="512"/>
         <source>Current color scheme</source>
         <translation>Huidig thema</translation>
     </message>
     <message>
-        <location filename="src/gui/Appearance.cpp" line="512"/>
         <source>Default color scheme</source>
         <translation>Standaardthema</translation>
     </message>
@@ -279,50 +264,95 @@
 <context>
     <name>AspectRatio</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="274"/>
         <source>&amp;Aspect ratio</source>
         <translation>&amp;Beeldverhouding</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="277"/>
         <source>&amp;Auto</source>
         <translation>&amp;Automatisch</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="286"/>
         <source>D&amp;epends on size</source>
         <translation>Afhank&amp;elijk van afmetingen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="287"/>
         <source>&amp;Disabled</source>
         <translation>Uitgeschakel&amp;d</translation>
     </message>
 </context>
 <context>
+    <name>AudioCD</name>
+    <message>
+        <source>AudioCD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose the drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No CD/DVD drives found!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose AudioCD image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Supported AudioCD images</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AudioCDDemux</name>
+    <message>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished">Volgnummer</translation>
+    </message>
+    <message>
+        <source>Error reading track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No CD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid path to CD drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No AudioCD found!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioChannels</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="408"/>
         <source>&amp;Channels</source>
         <translation>Aantal &amp;kanalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="411"/>
         <source>&amp;Autodetect</source>
         <translation>&amp;Automatisch detecteren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="413"/>
         <source>&amp;Mono</source>
         <translation>&amp;Mono</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="414"/>
         <source>&amp;Stereo</source>
         <translation>&amp;Stereo</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="419"/>
         <source>&amp;Other</source>
         <translation>&amp;Anders</translation>
     </message>
@@ -330,76 +360,72 @@
 <context>
     <name>AudioThr</name>
     <message>
-        <location filename="src/gui/AudioThr.cpp" line="97"/>
-        <location filename="src/gui/AudioThr.cpp" line="100"/>
         <source>Module</source>
         <translation>Module</translation>
     </message>
     <message>
-        <location filename="src/gui/AudioThr.cpp" line="97"/>
         <source>sets the parameters to</source>
         <translation>stelt de aanvullende opties in op</translation>
     </message>
     <message>
-        <location filename="src/gui/AudioThr.cpp" line="97"/>
         <source>channels</source>
         <translation>kanalen</translation>
     </message>
     <message>
-        <location filename="src/gui/AudioThr.cpp" line="97"/>
         <source>Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="src/gui/AudioThr.cpp" line="100"/>
         <source>requires a change in one of the forced parameters, sound disabled ...</source>
         <translation>vereist aanpassingen aan één van de ingestelde aanvullende opties - geluid is uitgeschakeld </translation>
     </message>
     <message>
-        <location filename="src/gui/AudioThr.cpp" line="434"/>
         <source>Error during initialization</source>
         <translation>Het initialiseren is mislukt</translation>
     </message>
 </context>
 <context>
+    <name>Cuvid</name>
+    <message>
+        <source>Adaptive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deinterlacing method</source>
+        <translation type="unfinished">Interliniëringsmethode</translation>
+    </message>
+</context>
+<context>
     <name>DeintSettingsW</name>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="50"/>
         <source>Remove interlacing</source>
         <translation>Bezig met verwijderen van interliniëring…</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="52"/>
         <source>Automatically detect interlaced frames</source>
         <translation>Geïnterlinieerde frames automatisch detecteren</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="55"/>
         <source>Doubles the the number of frames per second</source>
         <translation>Verdubbelt het aantal frames per seconde</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="59"/>
         <source>Automatically detect parity</source>
         <translation>Paren automatisch detecteren</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="64"/>
         <source>Vulkan Yadif spatial check</source>
         <translation>Vulkan Yadif spatieel controleren</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="83"/>
         <source>Deinterlacing method</source>
         <translation>Interliniëringsmethode</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="83"/>
         <source>software decoding</source>
         <translation>softwarematige decodering</translation>
     </message>
     <message>
-        <location filename="src/gui/DeintSettingsW.cpp" line="89"/>
         <source>Parity (if not detected automatically)</source>
         <translation>Paren (indien niet automatisch gedetecteerd)</translation>
     </message>
@@ -407,348 +433,676 @@
 <context>
     <name>DemuxerThr</name>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="144"/>
         <source>Seeking</source>
         <translation>Bezig met doorspoelen…</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="286"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="416"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="671"/>
         <source>Playback</source>
         <translation>Afspelen</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="343"/>
         <source>Opening</source>
         <translation>Bezig met openen…</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="356"/>
         <source>Cannot open</source>
         <translation>Het openen is mislukt</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="663"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="746"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="901"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="935"/>
         <source>Stream</source>
         <translation>Stream</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="753"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="908"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="942"/>
         <source>title</source>
         <translation>titel</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="755"/>
         <source>loaded from file</source>
         <translation>geladen uit bestand</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="757"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="920"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="962"/>
         <source>format</source>
         <translation>formaat</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="769"/>
         <source>Title</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="815"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="819"/>
         <source>File path</source>
         <translation>Bestandslocatie</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="820"/>
         <source>File name</source>
         <translation>Bestandsnaam</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="824"/>
         <source>Bitrate</source>
         <translation>Bitsnelheid</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="825"/>
         <source>Format</source>
         <translation>Formaat</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="828"/>
         <source>Save cover picture</source>
         <translation>Hoes opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="835"/>
         <source>Programs</source>
         <translation>Programma&apos;s</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="859"/>
         <source>Program</source>
         <translation>Programma</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="873"/>
         <source>Chapters</source>
         <translation>Hoofdstukken</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="877"/>
         <source>Chapter</source>
         <translation>Hoofdstuk</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="910"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="946"/>
         <source>codec</source>
         <translation>codec</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="911"/>
         <source>size</source>
         <translation>grootte</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="912"/>
         <source>aspect ratio</source>
         <translation>beeldverhouding</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="915"/>
         <source>FPS</source>
         <translation>FPS</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="917"/>
-        <location filename="src/gui/DemuxerThr.cpp" line="959"/>
         <source>bitrate</source>
         <translation>bitsnelheid</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="944"/>
         <source>artist</source>
         <translation>artiest</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="947"/>
         <source>sample rate</source>
         <translation>samplesnelheid</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="951"/>
         <source>mono</source>
         <translation>mono</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="953"/>
         <source>stereo</source>
         <translation>stereo</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="956"/>
         <source>channels</source>
         <translation>aantal kanalen</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="985"/>
         <source>Video streams</source>
         <translation>Videostreams</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="987"/>
         <source>Audio streams</source>
         <translation>Audiostreams</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="989"/>
         <source>Subtitles streams</source>
         <translation>Ondertitelstreams</translation>
     </message>
     <message>
-        <location filename="src/gui/DemuxerThr.cpp" line="991"/>
         <source>Attached files</source>
         <translation>Bijgevoegde bestanden</translation>
     </message>
 </context>
 <context>
+    <name>DownloadItemW</name>
+    <message>
+        <source>Download complete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Download aborted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Download error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Conversion aborted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Conversion error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation type="unfinished">Afspelen</translation>
+    </message>
+    <message>
+        <source>Download again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File size</source>
+        <translation type="unfinished">Bestandsgrootte</translation>
+    </message>
+    <message>
+        <source>Converting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop conversion</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Downloader</name>
+    <message>
+        <source>Downloader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Add</source>
+        <translation type="unfinished">&amp;Toevoegen</translation>
+    </message>
+    <message>
+        <source>Download directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Choose directory for downloaded files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear completed downloads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter the address for download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add, modify, or remove conversion presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Download</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Download and convert to &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Converter preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command line to execute after download.
+
+&lt;input/&gt; - specifies downloaded file.
+&lt;output&gt;%f.mp3&lt;/output&gt; - converted file will be input file with &quot;mp3&quot; extension.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Verwijderen</translation>
+    </message>
+    <message>
+        <source>Preset name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incorrect/empty name or command line!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command must contain &lt;input/&gt; tag!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Command must contain correct &lt;output&gt;file&lt;/output/&gt; tag!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset name already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot change downloading files directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DownloaderThread</name>
+    <message>
+        <source>Invalid address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>EntryProperties</name>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="58"/>
         <source>Properties</source>
         <translation>Eigenschappen</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="81"/>
         <source>Synchronize with file or directory</source>
         <translation>Synchroniseren met bestand of map</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="86"/>
         <source>Browse for a directory</source>
         <translation>Kies een map</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="91"/>
         <source>Browse for a file that contains more than one track</source>
         <translation>Kies een bestand dat meer dan één nummer bevat</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="111"/>
         <source>Open URL or directory containing chosen file</source>
         <translation>URL of map openen met gekozen bestand</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="164"/>
         <source>File size</source>
         <translation>Bestandsgrootte</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="184"/>
         <source>Choose a directory</source>
         <translation>Kies een map</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="186"/>
         <source>Choose a file that contains more than one track</source>
         <translation>Kies een map die meer dan één nummer bevat</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="229"/>
         <source>Incorrect path</source>
         <translation>Onjuiste locatie</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="229"/>
         <source>The specified path does not exist</source>
         <translation>De opgegeven locatie bestaat niet</translation>
     </message>
     <message>
-        <location filename="src/gui/EntryProperties.cpp" line="252"/>
         <source>Error while writing tags, please check if you have permission to modify the file!</source>
         <translation>Er is een fout opgetreden tijdens het wegschrijven van de tags. Controleer of u recht hebt om het bestand aan te passen!</translation>
     </message>
 </context>
 <context>
+    <name>EqualizerGUI</name>
+    <message>
+        <source>Equalizer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add new preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">Instellingen</translation>
+    </message>
+    <message>
+        <source>ON</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preamp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter new preset name</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFDemux</name>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished">Volgnummer</translation>
+    </message>
+</context>
+<context>
+    <name>FFTSpectrumW</name>
+    <message>
+        <source>FFT Spectrum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pointed frequency: %1 Hz</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FFmpeg</name>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">Geen</translation>
+    </message>
+    <message>
+        <source>Deinterlacing method</source>
+        <translation type="unfinished">Interliniëringsmethode</translation>
+    </message>
+</context>
+<context>
+    <name>FileAssociation</name>
+    <message>
+        <source>File association</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to associate files with QMPlay2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FormatContext</name>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished">Volgnummer</translation>
+    </message>
+</context>
+<context>
+    <name>GME</name>
+    <message>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copyright</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">Opmerking</translation>
+    </message>
+    <message>
+        <source>Voices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished">Volgnummer</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettings</name>
+    <message>
+        <source>Show covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show covers from directory if they aren&apos;t in the music file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enlarge small covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blurred covers as background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set key bindings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear covers cache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove youtube-dl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles encoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default audio language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default subtitles language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Screenshots path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Browse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use system icon set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatically check and download updates</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatically open video window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show tabs at the top of the main window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow only one instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always only display file names in playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remember repeat mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use proxy server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy server needs login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy server address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy server port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Read and display still images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use tray notifications as default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatically delete ungrouped entries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide artist metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatically restore main window when new video file is loaded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t load playlist files within other files</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Help</name>
     <message>
-        <location filename="src/gui/Main.cpp" line="223"/>
         <source>Open and play specified &lt;url&gt;.</source>
         <translation>Open QMPlay2 en speel de opgegeven &lt;url&gt; af.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="224"/>
         <source>Open new QMPlay2 instance and play specified &lt;url&gt;.</source>
         <translation>Open een nieuw venster en speel de opgegeven &lt;url&gt; af.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="225"/>
         <source>Add specified &lt;url&gt; to playlist.</source>
         <translation>Voeg de opgegeven &lt;url&gt; toe aan de afspeellijst.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="226"/>
         <source>Start the application with given &lt;profile name&gt;.</source>
         <translation>Open QMPlay2 met de opgegeven &lt;profielnaam&gt;.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="227"/>
         <source>Don&apos;t play after run (bypass &quot;Remember playback position&quot; option).</source>
         <translation>Speel niet af na het openen (en omzeil daarmee de optie ‘Afspeelpositie onthouden’).</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="228"/>
         <source>Toggle playback.</source>
         <translation>Afspelen/Pauzeren.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="229"/>
         <source>Start playback.</source>
         <translation>Afspelen.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="230"/>
         <source>Stop playback.</source>
         <translation>Stoppen met afspelen.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="231"/>
         <source>Ensure that the window will be visible if the application is running.</source>
         <translation>Focus het venster als QMPlay2 al geopend is.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="232"/>
         <source>Toggle fullscreen.</source>
         <translation>Beeldvullende modus aan/uit.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="233"/>
         <source>Set specified volume.</source>
         <translation>Stel het opgegeven volumeniveau in.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="234"/>
         <source>Set specified playback speed.</source>
         <translation>Stel de opgegeven afspeelsnelheid in.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="235"/>
         <source>Seek to the specified value.</source>
         <translation>Spoel door naar de opgegeven waarde.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="236"/>
         <source>Play next entry on playlist.</source>
         <translation>Speel het volgende afspeellijstitem af.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="237"/>
         <source>Play previous entry on playlist.</source>
         <translation>Speel het vorige afspeellijstitem af.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="238"/>
         <source>Terminate the application.</source>
         <translation>Sluit QMPlay2 af.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="239"/>
         <source>Display this help.</source>
         <translation>Toon deze hulp.</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="486"/>
         <source>&amp;Help</source>
         <translation>&amp;Hulp</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="488"/>
         <source>&amp;About QMPlay2</source>
         <translation>Over QMPl&amp;ay2</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="490"/>
         <source>&amp;Updates</source>
         <translation>&amp;Updates</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="493"/>
         <source>About &amp;Qt</source>
         <translation>Over &amp;Qt</translation>
     </message>
@@ -756,376 +1110,969 @@
 <context>
     <name>InfoDock</name>
     <message>
-        <location filename="src/gui/InfoDock.cpp" line="69"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location filename="src/gui/InfoDock.cpp" line="194"/>
         <source>Audio bitrate</source>
         <translation>Audio-bitsnelheid</translation>
     </message>
     <message>
-        <location filename="src/gui/InfoDock.cpp" line="200"/>
         <source>Video bitrate</source>
         <translation>Video-bitsnelheid</translation>
     </message>
     <message>
-        <location filename="src/gui/InfoDock.cpp" line="208"/>
         <source>visible</source>
         <translation>zichtbaar</translation>
     </message>
     <message>
-        <location filename="src/gui/InfoDock.cpp" line="210"/>
         <source>interlaced</source>
         <translation>geïnterlinieerd</translation>
     </message>
     <message>
-        <location filename="src/gui/InfoDock.cpp" line="216"/>
         <source>Buffer</source>
         <translation>Bufferen</translation>
     </message>
 </context>
 <context>
+    <name>Inputs</name>
+    <message>
+        <source>Tone generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>KeyBindingsDialog</name>
     <message>
-        <location filename="src/gui/KeyBindingsDialog.cpp" line="32"/>
         <source>Key bindings settings</source>
         <translation>Sneltoetsinstellingen</translation>
     </message>
 </context>
 <context>
+    <name>LastFM</name>
+    <message>
+        <source>LastFM login error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check login and password!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Logged in to LastFM!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LineEdit</name>
+    <message>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Lyrics</name>
+    <message>
+        <source>Lyrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lyrics not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MPDemux</name>
+    <message>
+        <source>Samples</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Patterns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MainWidget</name>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="181"/>
         <source>Stopped</source>
         <translation>Gestopt</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="249"/>
         <source>Main toolbar</source>
         <translation>Hoofdwerkbalk</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="347"/>
         <source>&amp;Hide menu bar</source>
         <translation>Menubalk verber&amp;gen</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="360"/>
         <source>&amp;Lock widgets</source>
         <translation>Widgets vergrende&amp;len</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="641"/>
         <source>&amp;Pause</source>
         <translation>&amp;Pauzeren</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="646"/>
         <source>&amp;Play</source>
         <translation>Afs&amp;pelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="973"/>
         <source>New window</source>
         <translation>Nieuw venster</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1240"/>
         <source>Choose files</source>
         <translation>Kies bestanden</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1244"/>
         <source>Choose directory</source>
         <translation>Kies een map</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1248"/>
         <source>Playlists</source>
         <translation>Afspeellijsten</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1255"/>
         <source>Choose playlist</source>
         <translation>Kies een afspeellijst</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1259"/>
         <source>Save playlist</source>
         <translation>Afspeellijst opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1263"/>
         <source>Save group</source>
         <translation>Groep opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1318"/>
-        <location filename="src/gui/MainWidget.cpp" line="1320"/>
         <source>Subtitles</source>
         <translation>Ondertiteling</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1322"/>
         <source>Choose subtitles</source>
         <translation>Kies ondertiteling</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1375"/>
         <source>Pointed position</source>
         <translation>Aangewezen positie</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1499"/>
         <source>Error while saving playlist</source>
         <translation>De afspeellijst kan niet worden opgeslagen</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1759"/>
         <source>Are you sure you want to quit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1762"/>
         <source>QMPlay2 is doing something in the background.</source>
         <translation>QMPlay2 is nog bezig met een achtergrondtaak.</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1764"/>
         <source>The update is being downloaded now.</source>
         <translation>De update wordt gedownload.</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1854"/>
         <source>&amp;Hide</source>
         <translation>&amp;Verbergen</translation>
     </message>
     <message>
-        <location filename="src/gui/MainWidget.cpp" line="1865"/>
         <source>&amp;Show</source>
         <translation>&amp;Tonen</translation>
     </message>
 </context>
 <context>
-    <name>MenuBar::Options</name>
+    <name>MediaBrowser</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="61"/>
-        <source>Create new profile</source>
-        <translation>Nieuw profiel aanmaken</translation>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="61"/>
-        <source>Enter new profile name:</source>
-        <translation>Geef het nieuwe profiel een naam:</translation>
+        <source>Play all</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="482"/>
-        <source>Remove</source>
-        <translation>Verwijderen</translation>
+        <source>Search on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Website doesn&apos;t exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connection error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MediaBrowserResults</name>
+    <message>
+        <source>Enqueue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation type="unfinished">Afspelen</translation>
+    </message>
+    <message>
+        <source>Open the page in the browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy page address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ModuleSettingsWidget</name>
+    <message>
+        <source>Enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic looking for multichannel device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum latency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AudioCD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use CDDB if CD-TEXT is not available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use CD-TEXT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cut frequency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Feed level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice removal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phase reverse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reverse the right channel phase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swap stereo channels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo surround</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dynamic range compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Release time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fast compression ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Overall compression ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Equalizer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sound equalizer quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>filter size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Very high</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slider count in sound equalizer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum frequency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum frequency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoder enabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decode MPEG4 videos</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable if you have problems with decoding MPEG4 (DivX5) videos</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use CUVID only when primary GPU is NVIDIA</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the program via MPRIS2 interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show user name in search results</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Display available subtitles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Display subtitles from YouTube. Follow default subtitles language and QMPlay2 language.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferred quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Download covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow to download big covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scrobble</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Last password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Demuxer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Try to automatically reconnect live streams on error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Software decoder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy decoded video to CPU memory (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decoder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>hardware decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Noise reduction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Zero-copy decoding on Intel hardware (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Better performance, but can cause garbage or might not work at all.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hurry up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip some frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force frame skipping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>4x smaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16x smaller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of threads used to decode video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Low resolution decoding (only some codecs)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Method of multithreaded decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Associate files with QMPlay2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select all</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add entry to the directories context menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add entry to the drives context menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set as default AudioCD player</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enqueue in QMPlay2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play in QMPlay2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Uncompressed PCM sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File extensions (semicolon separated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Format</source>
+        <translation type="unfinished">Formaat</translation>
+    </message>
+    <message>
+        <source>Channel count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rayman2 music (*.apm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resampling method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Additional notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Infinite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notification when volume changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notification when media changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notification when play state changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notification timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use a custom message for media change notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Body</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M3U support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XSPF support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation type="unfinished">Standaard</translation>
+    </message>
+    <message>
+        <source>Exclusive mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bit-perfect audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This sets the selected output device to the sample rate of the content being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SRT reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Classic subtitles reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the specified FPS in MicroDVD subtitles (if exists)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The maximum duration of subtitles without a specified length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linear scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refresh time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Displayed sound length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FFT spectrum size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use shared memory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XVideo outputs</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ModulesList</name>
+    <message>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NotifyService</name>
+    <message>
+        <source>Stopped</source>
+        <translation type="unfinished">Gestopt</translation>
+    </message>
+    <message>
+        <source>Playing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Paused</source>
+        <translation type="unfinished">Gepauzeerd</translation>
+    </message>
+    <message>
+        <source>Volume changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume: %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OSDSettings</name>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Margins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles alignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Outline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OpenGLCommon</name>
+    <message>
+        <source>Shader compile/link error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t init %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>texture map error</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Options</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="431"/>
         <source>Op&amp;tions</source>
         <translation>Op&amp;ties</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="434"/>
         <source>&amp;Settings</source>
         <translation>In&amp;stellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="435"/>
         <source>&amp;Renderer settings</source>
         <translation>Wee&amp;rgave-instellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="436"/>
         <source>&amp;Playback settings</source>
         <translation>Afs&amp;peelinstellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="437"/>
         <source>&amp;Modules settings</source>
         <translation>&amp;Module-instellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="441"/>
         <source>&amp;Profiles</source>
         <translation>&amp;Profielen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="446"/>
         <source>&amp;New Profile</source>
         <translation>&amp;Nieuw profiel</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="447"/>
         <source>&amp;Copy Profile</source>
         <translation>Profiel &amp;kopiëren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="452"/>
         <source>&amp;Default</source>
         <translation>Stan&amp;daard</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="479"/>
         <source>&amp;Show tray icon</source>
         <translation>&amp;Systeemvakpictogram tonen</translation>
+    </message>
+    <message>
+        <source>Create new profile</source>
+        <translation type="unfinished">Nieuw profiel aanmaken</translation>
+    </message>
+    <message>
+        <source>Enter new profile name:</source>
+        <translation type="unfinished">Geef het nieuwe profiel een naam:</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation type="unfinished">Verwijderen</translation>
+    </message>
+</context>
+<context>
+    <name>PipeWireWriter</name>
+    <message>
+        <source>Cannot open audio output stream</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PlayClass</name>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="405"/>
         <source>Loaded subtitles</source>
         <translation>De ondertiteling is geladen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="431"/>
-        <location filename="src/gui/PlayClass.cpp" line="763"/>
         <source>Play speed</source>
         <translation>Afspeelsnelheid</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="547"/>
         <source>No image rotation</source>
         <translation>Beeld niet draaien</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="550"/>
         <source>Horizontal flip</source>
         <translation>Beeld horizontaal spiegelen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="553"/>
         <source>Vertical flip</source>
         <translation>Beeld verticaal spiegelen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="557"/>
         <source>Rotation 270°</source>
         <translation>Beeld 270° draaien</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="559"/>
         <source>Rotation 180°</source>
         <translation>Beeld 180° draaien</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="565"/>
         <source>Rotation 90°</source>
         <translation>Beeld 90° draaien</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="576"/>
         <source>Stopped</source>
         <translation>Gestopt</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="590"/>
         <source>disabled</source>
         <translation>uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="594"/>
         <source>from</source>
         <translation>van</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="596"/>
         <source>to</source>
         <translation>tot</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="599"/>
         <source>A-B Repeat</source>
         <translation>A-B herhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="763"/>
         <source>Set playback speed (sec.)</source>
         <translation>Afspeelsnelheid (in sec.)</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="820"/>
         <source>Aspect ratio</source>
         <translation>Beeldverhouding</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="840"/>
         <source>Volume</source>
         <translation>Volumeniveau</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="850"/>
         <source>Muted sound</source>
         <translation>Het geluid is gedempt</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="861"/>
-        <location filename="src/gui/PlayClass.cpp" line="870"/>
-        <location filename="src/gui/PlayClass.cpp" line="875"/>
-        <location filename="src/gui/PlayClass.cpp" line="879"/>
         <source>Video delay</source>
         <translation>Videovertraging</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="875"/>
         <source>Set video delay (sec.)</source>
         <translation>Videovertraging instellen (in sec.)</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="888"/>
-        <location filename="src/gui/PlayClass.cpp" line="897"/>
-        <location filename="src/gui/PlayClass.cpp" line="904"/>
-        <location filename="src/gui/PlayClass.cpp" line="908"/>
         <source>Subtitles delay</source>
         <translation>Ondertitelvertraging</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="904"/>
         <source>Set subtitles delay (sec.)</source>
         <translation>Ondertitelvertraging instellen (in sec.)</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="918"/>
-        <location filename="src/gui/PlayClass.cpp" line="934"/>
         <source>Subtitles size</source>
         <translation>Ondertitelgrootte</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="949"/>
         <source>Audio off</source>
         <translation>Geen geluid afspelen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="956"/>
         <source>Video off</source>
         <translation>Geen beelden tonen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="963"/>
         <source>Subtitles off</source>
         <translation>Geen ondertiteling tonen</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="981"/>
         <source>Spherical view is not supported by this video output module</source>
         <translation>Bolweergave wordt niet ondersteund door deze video-uitvoermodule</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="1022"/>
         <source>Rotation is not supported by this video output module</source>
         <translation>Draaien wordt niet ondersteund door deze video-uitvoermodule</translation>
     </message>
     <message>
-        <location filename="src/gui/PlayClass.cpp" line="1212"/>
         <source>Playback has been incorrectly terminated!</source>
         <translation>Het afspelen is onjuist afgebroken!</translation>
     </message>
@@ -1133,200 +2080,316 @@
 <context>
     <name>Playback</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="325"/>
         <source>&amp;Playback</source>
         <translation>Afs&amp;pelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="327"/>
         <source>&amp;Enable audio</source>
         <translation>G&amp;eluid afspelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="335"/>
         <source>&amp;Enable video</source>
         <translation>B&amp;eelden tonen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="341"/>
         <source>Set &amp;video delay</source>
         <translation>&amp;Videovertraging instellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="342"/>
         <source>&amp;Delay video</source>
         <translation>Vi&amp;deo vertragen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="343"/>
         <source>&amp;Speed up video</source>
         <translation>Video ver&amp;snellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="345"/>
         <source>&amp;Enable subtitles</source>
         <translation>Ond&amp;ertiteling tonen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="347"/>
         <source>Add &amp;subtities from file</source>
         <translation>Ondertiteling toevoegen uit be&amp;stand</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="348"/>
         <source>Set &amp;subtitles delay</source>
         <translation>Ondertitelvertraging in&amp;stellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="349"/>
         <source>&amp;Delay subtitiles</source>
         <translation>On&amp;dertiteling vertragen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="350"/>
         <source>&amp;Speed up subtitles</source>
         <translation>Ondertiteling ver&amp;snellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="351"/>
         <source>Scale up subt&amp;itles</source>
         <translation>Ondert&amp;iteling vergroten</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="352"/>
         <source>Scale down sub&amp;titles</source>
         <translation>Onder&amp;titeling verkleinen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="354"/>
         <source>&amp;Screen shot</source>
         <translation>&amp;Schermfoto maken</translation>
     </message>
 </context>
 <context>
+    <name>PlaybackSettings</name>
+    <message>
+        <source>Use available replay gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album mode for replay gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Amplify</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Partially checked means that there is a delay between click and pausing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Left mouse button on video dock toggles playback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Middle mouse button on video dock toggles fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep video delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fade sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep subtitles scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep subtitles delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video to audio sync (frame skipping)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Short seeking (left and right arrows)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>sec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Long seeking (up and down arrows)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Local buffer size (A/V packages count)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Network buffer size (A/V packages count)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Percent of packages for backwards rewinding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start playback internet stream if it is buffered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force samplerate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Force channels conversion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use audio resampler and channel conversion before filters and visualizations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keep aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accurate seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play next entry after playback error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remember playback position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse wheel action on video dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse wheel scrolls music/movie</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mouse wheel changes the volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remember video equalizer settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show buffered data indicator on slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Store aspect ratio and zoom in config file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unpause when seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable subtitles at program startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remember audio/video/subtitles enabled state</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Player</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="174"/>
         <source>&amp;Skip</source>
         <translation>Over&amp;slaan</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="175"/>
         <source>&amp;Stop after playing</source>
         <translation>&amp;Stoppen na afspelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="199"/>
         <source>&amp;Player</source>
         <translation>S&amp;peler</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="202"/>
         <source>&amp;Stop</source>
         <translation>&amp;Stoppen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="203"/>
         <source>&amp;Next</source>
         <translation>Volge&amp;nde</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="204"/>
         <source>&amp;Previous</source>
         <translation>&amp;Vorige</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="205"/>
         <source>Previous &amp;frame</source>
         <translation>Vorig &amp;frame</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="206"/>
         <source>Next &amp;frame</source>
         <translation>Volgend &amp;frame</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="212"/>
         <source>A&amp;-B Repeat</source>
         <translation>A&amp;-B herhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="215"/>
         <source>Seek &amp;forward</source>
         <translation>&amp;Vooruitspoelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="216"/>
         <source>Seek &amp;backward</source>
         <translation>&amp;Terugspoelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="217"/>
         <source>Long &amp;seek &amp;forward</source>
         <translation>Lang door&amp;spoe&amp;len</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="218"/>
         <source>Long s&amp;eek backward</source>
         <translation>Lang t&amp;erugspoelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="220"/>
         <source>Fa&amp;ster</source>
         <translation>&amp;Sneller</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="221"/>
         <source>Slowe&amp;r</source>
         <translation>Langzame&amp;r</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="222"/>
         <source>&amp;Set speed</source>
         <translation>&amp;Snelheid instellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="224"/>
         <source>Zoom i&amp;n</source>
         <translation>I&amp;nzoomen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="225"/>
         <source>Zoom ou&amp;t</source>
         <translation>Ui&amp;tzoomen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="226"/>
         <source>Toggle &amp;aspect ratio</source>
         <translation>&amp;Andere beeldverhouding gebruiken</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="231"/>
         <source>Reset image &amp;settings</source>
         <translation>Standaardwaarden her&amp;stellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="234"/>
         <source>Volume &amp;up</source>
         <translation>Vol&amp;ume omhoog</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="235"/>
         <source>Volume &amp;down</source>
         <translation>Vol&amp;ume omlaag</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="236"/>
         <source>&amp;Mute</source>
         <translation>De&amp;mpen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="243"/>
         <source>Detach from receiving &amp;commands</source>
         <translation>Loskoppelen van ontvangen en opdra&amp;chten</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="249"/>
         <source>Suspend after playbac&amp;k is finished</source>
         <translation>In pau&amp;zestand zetten nadat afspelen is voltooid</translation>
     </message>
@@ -1334,112 +2397,90 @@
 <context>
     <name>Playlist</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="127"/>
         <source>&amp;Playlist</source>
         <translation>Afs&amp;peellijst</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="133"/>
         <source>&amp;Stop loading</source>
         <translation>&amp;Stoppen met laden</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="135"/>
         <source>&amp;Synchronize groups</source>
         <translation>Groepen &amp;synchroniseren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="136"/>
         <source>&amp;Quick group synchronization</source>
         <translation>&amp;Groepen snel synchroniseren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="138"/>
         <source>Load &amp;list</source>
         <translation>&amp;Lijst laden</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="139"/>
         <source>Save &amp;list</source>
         <translation>&amp;Lijst opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="140"/>
         <source>Save &amp;group</source>
         <translation>&amp;Groep opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="143"/>
         <source>&amp;Always sync</source>
         <translation>&amp;Altijd synchroniseren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="145"/>
         <source>&amp;Remove selected entries</source>
         <translation>Selectie w&amp;issen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="146"/>
         <source>Remove entries &amp;without groups</source>
         <translation>Ongegroepeerde items &amp;wissen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="147"/>
         <source>&amp;Clear list</source>
         <translation>Lijst wi&amp;ssen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="149"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiëren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="150"/>
         <source>&amp;Paste</source>
         <translation>&amp;Plakken</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="153"/>
         <source>&amp;Extensions</source>
         <translation>Bestands&amp;extensies</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="158"/>
         <source>&amp;Create &amp;group</source>
         <translation>&amp;Groep samenstellen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="159"/>
         <source>&amp;Rename</source>
         <translation>Naam &amp;wijzigen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="161"/>
         <source>&amp;Find entries</source>
         <translation>Items &amp;zoeken</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="168"/>
         <source>&amp;Collapse all</source>
         <translation>Alles in&amp;klappen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="169"/>
         <source>&amp;Expand all</source>
         <translation>All&amp;es uitklappen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="171"/>
         <source>&amp;Go to the playback</source>
         <translation>&amp;Ga naar huidige nummer</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="173"/>
         <source>&amp;Enqueue</source>
         <translation>To&amp;evoegen aan wachtrij</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="177"/>
         <source>&amp;Properties</source>
         <translation>Eigenscha&amp;ppen</translation>
     </message>
@@ -1447,34 +2488,26 @@
 <context>
     <name>PlaylistDock</name>
     <message>
-        <location filename="src/gui/PlaylistDock.cpp" line="42"/>
-        <location filename="src/gui/PlaylistDock.cpp" line="517"/>
-        <location filename="src/gui/PlaylistDock.cpp" line="532"/>
         <source>Playlist</source>
         <translation>Afspeellijst</translation>
     </message>
     <message>
-        <location filename="src/gui/PlaylistDock.cpp" line="47"/>
         <source>Filter entries</source>
         <translation>Items filteren</translation>
     </message>
     <message>
-        <location filename="src/gui/PlaylistDock.cpp" line="517"/>
         <source>Are you sure you want to delete ungrouped entries?</source>
         <translation>Weet u zeker dat u ongegroepeerde items wilt wissen?</translation>
     </message>
     <message>
-        <location filename="src/gui/PlaylistDock.cpp" line="532"/>
         <source>Are you sure you want to clear the list?</source>
         <translation>Weet u zeker dat u de lijst wilt wissen?</translation>
     </message>
     <message>
-        <location filename="src/gui/PlaylistDock.cpp" line="657"/>
         <source>Playlist is being loaded now...</source>
         <translation>Bezig met laden van afspeellijst…</translation>
     </message>
     <message>
-        <location filename="src/gui/PlaylistDock.cpp" line="659"/>
         <source>Visible entries</source>
         <translation>Getoonde items</translation>
     </message>
@@ -1482,20 +2515,66 @@
 <context>
     <name>PlaylistWidget</name>
     <message>
-        <location filename="src/gui/PlaylistWidget.cpp" line="1252"/>
         <source>Un&amp;lock</source>
         <translation>Ontgrende&amp;len</translation>
     </message>
     <message>
-        <location filename="src/gui/PlaylistWidget.cpp" line="1252"/>
         <source>&amp;Lock</source>
         <translation>Vergrende&amp;len</translation>
     </message>
 </context>
 <context>
+    <name>PortAudioWriter</name>
+    <message>
+        <source>Cannot open audio output stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PulseAudioWriter</name>
+    <message>
+        <source>Cannot open audio output stream</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback error</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QMPlay2CoreClass</name>
+    <message>
+        <source>mismatch module API version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>mismatch module Qt version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too old QMPlay2 library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>invalid QMPlay2 library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>duplicated module name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Can&apos;t open log file</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QMPlay2GUIClass</name>
     <message>
-        <location filename="src/gui/Main.cpp" line="86"/>
         <source>Saving cover picture</source>
         <translation>Bezig met opslaan van hoes…</translation>
     </message>
@@ -1503,318 +2582,420 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="src/gui/Main.cpp" line="794"/>
         <source>QtSvg icon engine plugin doesn&apos;t exist.
 QMPlay2 will not scale up icons!</source>
         <translation>De QtSVG-pictogramaandrijvingsplug-in is niet aangetroffen.
 Pictogrammen worden niet vergroot.</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="833"/>
         <source>QMPlay2 has been updated to version</source>
         <translation>QMPlay2 isn bijgewerkt naar versie</translation>
     </message>
     <message>
-        <location filename="src/gui/Main.cpp" line="840"/>
         <source>QMPlay2 hasn&apos;t been updated. Do you want to run the update (recommended)?</source>
         <translation>QMPlay2 is niet bijgewerkt. Wilt u de update nu installeren (aanbevolen)?</translation>
     </message>
 </context>
 <context>
+    <name>Radio</name>
+    <message>
+        <source>My radio stations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load radio station list from file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save radio station list to file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add new radio station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit selected radio station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove selected radio station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adding a new radio station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internet radios</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Naam</translation>
+    </message>
+    <message>
+        <source>Tag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation type="unfinished">Afspelen</translation>
+    </message>
+    <message>
+        <source>Enqueue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add to my radio stations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open radio website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Address</source>
+        <translation type="unfinished">Adres</translation>
+    </message>
+    <message>
+        <source>Editing selected radio station</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load radio station list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save radio station list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Radio station with given name already exists!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RadioBrowserModel</name>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished">Naam</translation>
+    </message>
+    <message>
+        <source>Stream info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Country</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Repeat</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="253"/>
         <source>&amp;Repeat</source>
         <translation>He&amp;rhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="256"/>
         <source>&amp;No repeating</source>
         <translation>&amp;Niet herhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="258"/>
         <source>&amp;Entry repeating</source>
         <translation>It&amp;em herhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="259"/>
         <source>&amp;Group repeating</source>
         <translation>&amp;Groep herhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="260"/>
         <source>&amp;Playlist repeating</source>
         <translation>Afs&amp;peellijst herhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="262"/>
         <source>R&amp;andom</source>
         <translation>Willekeu&amp;rig</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="263"/>
         <source>Random in &amp;group</source>
         <translation>Willekeurig in &amp;groep</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="265"/>
         <source>Random and &amp;repeat</source>
         <translation>Willekeurig en he&amp;rhalen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="266"/>
         <source>Random in group and repea&amp;t</source>
         <translation>Willekeurig in groep en herha&amp;len</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="268"/>
         <source>&amp;Stop playback after every file</source>
         <translation>&amp;Stoppen met afspelen na elk bestand</translation>
     </message>
 </context>
 <context>
+    <name>ResultsYoutube</name>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Audio and video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Audio only</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play</source>
+        <translation type="unfinished">Afspelen</translation>
+    </message>
+    <message>
+        <source>Enqueue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open the page in the browser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy page address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SIDPlay</name>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished">Volgnummer</translation>
+    </message>
+</context>
+<context>
     <name>SettingsWidget</name>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="274"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="282"/>
         <source>Apply</source>
         <translation>Toepassen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="286"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="309"/>
         <source>General settings</source>
         <translation>Algemene instellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="340"/>
-        <location filename="src/gui/SettingsWidget.cpp" line="341"/>
         <source>Default or first stream</source>
         <translation>Standaard of eerste stream</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="353"/>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="393"/>
         <source>Automatically check for updates</source>
         <translation>Automatisch controleren op updates</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="448"/>
         <source>Legacy video output priority</source>
         <translation>Uitvoerprioriteit van verouderde video&apos;s</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="449"/>
         <source>Audio output priority</source>
         <translation>Uitvoerprioriteit van audio</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="450"/>
         <source>Decoders priority</source>
         <translation>Decoderingsprioriteit</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="491"/>
         <source>Playback settings</source>
         <translation>Afspeelinstellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="561"/>
         <source>Slower, but more accurate seeking.
 Partially checked doesn&apos;t affect seeking on slider.</source>
         <translation>Langzamer, maar nauwkeuriger doorspoelen.
 Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="574"/>
         <source>Modules</source>
         <translation>Modules</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="584"/>
         <source>Contains</source>
         <translation>Bevat</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="625"/>
         <source>Subtitles</source>
         <translation>Ondertiteling</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="627"/>
         <source>Colors and borders</source>
         <translation>Kleuren en randen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="630"/>
         <source>Margins and alignment</source>
         <translation>Marges en uitlijning</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="633"/>
         <source>Fonts and spacing</source>
         <translation>Lettertypen en afstand</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="636"/>
         <source>Use the same size</source>
         <translation>Dezelfde grootte gebruiken</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="639"/>
         <source>Apply for ASS/SSA subtitles</source>
         <translation>Toepassen op ass-/ssa-ondertiteling</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="654"/>
         <source>OSD</source>
         <translation>OSD</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="656"/>
         <source>OSD enabled</source>
         <translation>OSD is ingeschakeld</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="663"/>
         <source>Video filters</source>
         <translation>Videofilters</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="684"/>
         <source>Software video filters</source>
         <translation>Softwarematige videofilters</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="696"/>
         <source>Hardware accelerated video filters</source>
         <translation>Hardwareversnelde videofilters</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="764"/>
         <source>Legacy</source>
         <translation>Verouderd</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="766"/>
         <source>OpenGL</source>
         <translation>OpenGL</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="769"/>
         <source>Vulkan</source>
         <translation>Vulkan</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="780"/>
         <source>active</source>
         <translation>ingeschakeld</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="780"/>
         <source>inactive</source>
         <translation>uitgeschakeld</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="791"/>
         <source>Changing renderer</source>
         <translation>Andere renderer kiezen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="791"/>
         <source>To set up a new renderer, the program will start again!</source>
         <translation>Herstart QMPlay2 om de wijziging toe te passen.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="798"/>
         <source>Vertical synchronization (V-Sync)</source>
         <translation>Verticale synchronisatie (V-Sync)</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="801"/>
         <source>Bypass compositor in full screen</source>
         <translation>Hardwareversnelling uitschakelen in beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="804"/>
         <source>This can improve performance if X11 compositor supports it</source>
         <translation>Dit kan voor betere prestaties zorgen, maar dient wel te worden ondersteund door de gebruikte X11-hardwareversnelling</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="815"/>
         <source>Use QMPlay2 video output modules. This will also be used if other renderers aren&apos;t available.</source>
         <translation>Gebruik QMPlay2-video-uitvoermodules. Deze worden tevens gebruikt als er geen andere renderers beschikbaar zijn.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="827"/>
         <source>Use OpenGL on entire window</source>
         <translation>OpenGL gebruiken in gehele venster</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="834"/>
         <source>This can improve performance. Some video drivers can crash when enabled.</source>
         <translation>Dit kan voor betere prestaties zorgen, maar kan bij sommige videostuurprogramma&apos;s leiden tot crashes.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="843"/>
         <source>Use QOpenGLWidget (render-to-texture), also enable OpenGL for visualizations. Use with caution, it can reduce performance of video playback.</source>
         <translation>Gebruik QOpenGLWidget (render-naar-textuur) en OpenGL bij visualisaties. Let op: dit kan leiden tot slechtere prestaties tijdens het afspelen van video&apos;s.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="883"/>
         <source>Changing OpenGL mode</source>
         <translation>Andere OpenGL-modus kiezen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="883"/>
         <source>To set up a new OpenGL mode, the program will start again!</source>
         <translation>Herstart QMPlay2 om de wijziging toe te passen.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="903"/>
         <source>Use GPU deinterlacing for CPU-decoded video</source>
         <translation>GPU-interliniëring gebruiken bij door de cpu gerenderde video&apos;s</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="904"/>
         <source>Force Vulkan Yadif deinterlacing for all hardware decoders</source>
         <translation>Vulkan Yadif-interliniëring gebruiken bij alle hardwarematige decoderingen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="905"/>
         <source>High quality image scaling down</source>
         <translation>Afbeeldingen verkleinen met hoge kwaliteit</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="906"/>
         <source>High quality image scaling up</source>
         <translation>Afbeeldingen vergroten met hoge kwaliteit</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="951"/>
         <source>First available device</source>
         <translation>Eerste beschikbare apparaat</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="956"/>
         <source>No supported devices found</source>
         <translation>Er zijn geen ondersteunde apparaten aangetroffen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="962"/>
         <source>Partially checked (default):
   - MAILBOX (tear-free) is the preferred present mode
   - FIFO (V-Sync) should not be used in windowed mode</source>
@@ -1823,82 +3004,66 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
   - FIFO (V-Sync) wordt niet gebruikt in de venstermodus</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="971"/>
         <source>Allow for exclusive fullscreen. This can improve performance.</source>
         <translation>Ken de hoogste prioriteit toe in de beeldvullende modus. Dit kan voor betere prestaties zorgen.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="987"/>
         <source>Very slow if used with sharpness</source>
         <translation>Dit is erg langzaam i.c.m. verscherping</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="991"/>
         <source>Device:</source>
         <translation>Apparaat:</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1037"/>
         <source>Renderer:</source>
         <translation>Renderer:</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1046"/>
         <source>Renderer settings</source>
         <translation>Rendererinstellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1112"/>
         <source>New language</source>
         <translation>Andere taal kiezen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1112"/>
         <source>To set up a new language, the program will start again!</source>
         <translation>Herstart QMPlay2 om de wijziging toe te passen.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1121"/>
         <source>Changing icons</source>
         <translation>Andere pictogrammen kiezen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1121"/>
         <source>To apply the icons change, the program will start again!</source>
         <translation>Herstart QMPlay2 om de wijziging toe te passen.</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1391"/>
         <source>Choose directory</source>
         <translation>Kies een map</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1405"/>
         <source>Confirm clearing the cached covers</source>
         <translation>Bevestig het wissen van tijdelijk opgeslagen hoezen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1405"/>
         <source>Do you want to delete all cached covers?</source>
         <translation>Weet u zeker dat u alle tijdelijk opgeslagen hoezen wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1423"/>
         <source>Confirm &quot;youtube-dl&quot; deletion</source>
         <translation>Bevestig het verwijderen van ‘youtube-dl’</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1423"/>
         <source>Do you want to remove &quot;youtube-dl&quot; software?</source>
         <translation>Weet u zeker u ‘youtube-dl’ wilt verwijderen?</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1431"/>
         <source>Confirm settings deletion</source>
         <translation>Bevestig het wissen van de instellingen</translation>
     </message>
     <message>
-        <location filename="src/gui/SettingsWidget.cpp" line="1431"/>
         <source>Do you really want to clear all settings?</source>
         <translation>Weet u zeker alle instellingen wilt wissen?</translation>
     </message>
@@ -1906,271 +3071,304 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
 <context>
     <name>ShortcutHandler</name>
     <message>
-        <location filename="src/gui/ShortcutHandler.cpp" line="60"/>
         <source>Action</source>
         <translation>Actie</translation>
     </message>
     <message>
-        <location filename="src/gui/ShortcutHandler.cpp" line="62"/>
         <source>Key sequence</source>
         <translation>Sneltoets</translation>
     </message>
 </context>
 <context>
+    <name>SimpleVisW</name>
+    <message>
+        <source>Simple visualization</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Sort</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="189"/>
         <source>&amp;Sort</source>
         <translation>&amp;Sorteren</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="191"/>
         <source>&amp;From the shortest to the longest</source>
         <translation>&amp;Van kort naar lang</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="192"/>
         <source>&amp;From the longest to the shortest</source>
         <translation>&amp;Van lang naar kort</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="194"/>
         <source>&amp;A-Z</source>
         <translation>&amp;A-Z</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="195"/>
         <source>&amp;Z-A</source>
         <translation>&amp;Z-A</translation>
     </message>
 </context>
 <context>
+    <name>StreamInfo</name>
+    <message>
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Artist</source>
+        <translation type="unfinished">Artiest</translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished">Album</translation>
+    </message>
+    <message>
+        <source>Genre</source>
+        <translation type="unfinished">Genre</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Comment</source>
+        <translation type="unfinished">Opmerking</translation>
+    </message>
+    <message>
+        <source>Lyrics</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>TagEditor</name>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="161"/>
         <source>Add tags</source>
         <translation>Tags toevoegen</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="166"/>
-        <location filename="src/gui/TagEditor.cpp" line="170"/>
         <source>None</source>
         <translation>Geen</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="172"/>
         <source>Cover</source>
         <translation>Hoes</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="175"/>
         <source>Load cover picture</source>
         <translation>Hoesafbeelding laden</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="177"/>
         <source>Save cover picture</source>
         <translation>Hoesafbeelding opslaan</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="190"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="191"/>
         <source>Artist</source>
         <translation>Artiest</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="192"/>
         <source>Album</source>
         <translation>Album</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="193"/>
         <source>Comment</source>
         <translation>Opmerking</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="194"/>
         <source>Genre</source>
         <translation>Genre</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="195"/>
         <source>Year</source>
         <translation>Jaar</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="196"/>
         <source>Track</source>
         <translation>Volgnummer</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="637"/>
         <source>Loading cover picture</source>
         <translation>Bezig met laden van hoes…</translation>
     </message>
     <message>
-        <location filename="src/gui/TagEditor.cpp" line="637"/>
         <source>Pictures</source>
         <translation>Afbeeldingen</translation>
     </message>
 </context>
 <context>
+    <name>ToneGenerator</name>
+    <message>
+        <source>Tone generator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hz</source>
+        <translation type="unfinished">Hz</translation>
+    </message>
+</context>
+<context>
     <name>Updater</name>
     <message>
-        <location filename="src/gui/Updater.cpp" line="53"/>
         <source>QMPlay2 updates</source>
         <translation>QMPlay2-updates</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="57"/>
         <source>Download update</source>
         <translation>Update downloaden</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="58"/>
         <source>Apply update</source>
         <translation>Update installeren</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="101"/>
         <source>Checking for updates</source>
         <translation>Bezig met controleren op updates…</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="168"/>
         <source>Update is available for QMPlay2!</source>
         <translation>Er is een update beschikbaar!</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="171"/>
         <source>New QMPlay2 version: %1</source>
         <translation>Nieuwe QMPlay2-versie: %1</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="178"/>
         <source>No update available</source>
         <translation>Er is geen update beschikbaar</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="187"/>
         <source>Error creating update file</source>
         <translation>Het updatebestand kan niet worden aangemaakt</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="194"/>
         <source>This auto-update is ignored, press the button to update</source>
         <translation>Deze automatische update wordt genegeerd - klik op de knop om bij te werken</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="199"/>
         <source>Application is up-to-date</source>
         <translation>QMPlay2 is actueel</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="204"/>
-        <location filename="src/gui/Updater.cpp" line="209"/>
         <source>Error checking for updates</source>
         <translation>Er kan niet worden gecontroleerd op updates</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="243"/>
         <source>The update has been downloaded</source>
         <translation>De update is gedownload</translation>
     </message>
     <message>
-        <location filename="src/gui/Updater.cpp" line="250"/>
         <source>Error downloading the update</source>
         <translation>De update kan niet worden gedownload</translation>
     </message>
 </context>
 <context>
+    <name>VAAPI</name>
+    <message>
+        <source>Unsupported deinterlacing algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cannot open video filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VDPAU</name>
+    <message>
+        <source>Unsupported image sharpness filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsupported deinterlacing algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsupported noise reduction filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VFilters</name>
+    <message>
+        <source>Produce one extra frame which is average of two neighbour frames</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VideoAdjustmentW</name>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="43"/>
         <source>Brightness</source>
         <translation>Helderheid</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="44"/>
         <source>Contrast</source>
         <translation>Contrast</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="45"/>
         <source>Saturation</source>
         <translation>Verzadiging</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="46"/>
         <source>Hue</source>
         <translation>Tint</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="47"/>
         <source>Sharpness</source>
         <translation>Scherpte</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="95"/>
         <source>Reset</source>
         <translation>Standaardwaarden</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="101"/>
         <source>Reset video adjustments</source>
         <translation>Herstel de video-aanpassingen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="148"/>
         <source>Brightness down</source>
         <translation>Helderheid verlagen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="149"/>
         <source>Brightness up</source>
         <translation>Helderheid verhogen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="151"/>
         <source>Contrast down</source>
         <translation>Contrast verlagen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="152"/>
         <source>Contrast up</source>
         <translation>Contrast verhogen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="154"/>
         <source>Saturation down</source>
         <translation>Minder verzadiging</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="155"/>
         <source>Saturation up</source>
         <translation>Meer verzadiging</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="157"/>
         <source>Hue down</source>
         <translation>Tint verlagen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="158"/>
         <source>Hue up</source>
         <translation>Tint verhogen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="160"/>
         <source>Sharpness down</source>
         <translation>Minder verscherping</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoAdjustmentW.cpp" line="161"/>
         <source>Sharpness up</source>
         <translation>Meer verscherping</translation>
     </message>
@@ -2178,7 +3376,6 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
 <context>
     <name>VideoDock</name>
     <message>
-        <location filename="src/gui/VideoDock.cpp" line="50"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
@@ -2186,37 +3383,30 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
 <context>
     <name>VideoFilters</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="374"/>
         <source>Video &amp;filters</source>
         <translation>Video&amp;filters</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="377"/>
         <source>Video &amp;adjustment</source>
         <translation>Video-&amp;aanpassingen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="399"/>
         <source>&amp;Spherical view</source>
         <translation>&amp;Bolweergave</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="401"/>
         <source>&amp;Horizontal flip</source>
         <translation>&amp;Horizontaal spiegelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="402"/>
         <source>&amp;Vertical flip</source>
         <translation>&amp;Verticaal spiegelen</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="403"/>
         <source>&amp;Rotate 90°</source>
         <translation>90° d&amp;raaien</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="405"/>
         <source>&amp;More filters</source>
         <translation>&amp;Meer filters</translation>
     </message>
@@ -2224,25 +3414,28 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
 <context>
     <name>VideoThr</name>
     <message>
-        <location filename="src/gui/VideoThr.cpp" line="266"/>
         <source>Cannot initialize the deinterlacing filter</source>
         <translation>Het interliniëringsfilter kan niet worden geladen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoThr.cpp" line="285"/>
         <source>Error initializing filter</source>
         <translation>Het filter kan niet worden geladen</translation>
     </message>
     <message>
-        <location filename="src/gui/VideoThr.cpp" line="808"/>
         <source>Cannot create screenshot</source>
         <translation>Er kan geen schermfoto worden gemaakt</translation>
     </message>
 </context>
 <context>
+    <name>VisWidget</name>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">Instellingen</translation>
+    </message>
+</context>
+<context>
     <name>VolWidget</name>
     <message>
-        <location filename="src/gui/VolWidget.cpp" line="44"/>
         <source>Split channels</source>
         <translation>Kanalen splitsen</translation>
     </message>
@@ -2250,7 +3443,6 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
 <context>
     <name>Widgets</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="108"/>
         <source>&amp;Widgets</source>
         <translation>&amp;Widgets</translation>
     </message>
@@ -2258,29 +3450,110 @@ Kruis half aan om dit niet toe te passen op de schuifbalk.</translation>
 <context>
     <name>Window</name>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="96"/>
         <source>&amp;Window</source>
         <translation>&amp;Venster</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="99"/>
         <source>&amp;Full screen</source>
         <translation>&amp;Beeldvullende modus</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="100"/>
         <source>&amp;Compact view</source>
         <translation>&amp;Compacte weergave</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="102"/>
         <source>&amp;Always on top</source>
         <translation>&amp;Altijd bovenop</translation>
     </message>
     <message>
-        <location filename="src/gui/MenuBar.cpp" line="104"/>
         <source>&amp;Close</source>
         <translation>&amp;Sluiten</translation>
+    </message>
+</context>
+<context>
+    <name>YouTube</name>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation type="unfinished">Instellingen</translation>
+    </message>
+    <message>
+        <source>Preferred quality</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Relevance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Upload date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sort search results by ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search on YouTube</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connection error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playlist</source>
+        <translation type="unfinished">Afspeellijst</translation>
+    </message>
+    <message>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Publish time</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YouTubeDL</name>
+    <message>
+        <source>Downloading &quot;youtube-dl&quot;, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;youtube-dl&quot; download has been aborted!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;youtube-dl&quot; has been successfully downloaded!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;youtube-dl&quot; download has failed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Updating &quot;youtube-dl&quot;, please wait...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;youtube-dl&quot; has been successfully updated!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;youtube-dl&quot; update has been aborted!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/lang/pl.ts
+++ b/lang/pl.ts
@@ -2794,6 +2794,10 @@ QMPlay2 nie będzie skalować ikon!</translation>
         <source>Audio only</source>
         <translation>Tylko dźwięk</translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/pt_BR.ts
+++ b/lang/pt_BR.ts
@@ -2805,6 +2805,10 @@ QMPlay2 will not scale up icons!</source>
         <source>Copy page address</source>
         <translation>Copiar endereço da página</translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>
@@ -3218,7 +3222,7 @@ Partially checked doesn&apos;t affect seeking on slider.</source>
     </message>
     <message>
         <source>Hz</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Hz</translation>
     </message>
 </context>
 <context>

--- a/lang/ru.ts
+++ b/lang/ru.ts
@@ -2791,6 +2791,10 @@ QMPlay2 не будет отображать значки!</translation>
         <source>Audio only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation>Показать похожие</translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/uk.ts
+++ b/lang/uk.ts
@@ -2794,6 +2794,10 @@ QMPlay2 не масштабуватиме іконки!</translation>
         <source>Audio only</source>
         <translation>Лише аудіо</translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/lang/zh.ts
+++ b/lang/zh.ts
@@ -2794,6 +2794,10 @@ QMPlay2 将不会增加图标！</translation>
         <source>Audio only</source>
         <translation>仅音频</translation>
     </message>
+    <message>
+        <source>Show related</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SIDPlay</name>

--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -21,7 +21,6 @@
 #include <YouTubeDL.hpp>
 #include <LineEdit.hpp>
 
-#include <QtGlobal>
 #include <QLoggingCategory>
 #include <QStringListModel>
 #include <QDesktopServices>

--- a/src/modules/Extensions/YouTube.hpp
+++ b/src/modules/Extensions/YouTube.hpp
@@ -45,6 +45,11 @@ public:
     ResultsYoutube();
     ~ResultsYoutube();
 
+signals:
+    /// Signals when related items are requested for an item.
+    /** Is listened to by YouTube::fetchRelated(). */
+    void requestRelated(const QString contentId);
+
 private:
     void playOrEnqueue(const QString &param, QTreeWidgetItem *tWI, const QString &addrParam = QString());
 
@@ -53,6 +58,9 @@ private slots:
 
     void openPage();
     void copyPageURL();
+
+    /// Called when user clicks on "Show related" in context menu, gets the item's contentId and triggers requestRelated().
+    void showRelated();
 
     void contextMenu(const QPoint &p);
 };
@@ -105,6 +113,13 @@ private slots:
     void searchTextEdited(const QString &text);
     void search();
 
+    /// Fetches related items for video given by contentId.
+    /** Creates a network request for related items. The reply is handled by handleRelatedReply(). */
+    void fetchRelated(const QString &contentId);
+
+    /// Handles reply for request sent by fetchRelated().
+    void handleRelatedReply(QByteArray replyData);
+
     void netFinished(NetworkReply *reply);
 
     void searchMenu();
@@ -119,6 +134,9 @@ private:
 
     void setAutocomplete(const QByteArray &data);
     void setSearchResults(const QJsonObject &jsonObj, bool isContinuation);
+
+    /// Writes list of related items into YT browser widget.
+    void setRelatedResults(const QJsonObject &jsonObj, bool isContinuation);
 
     QStringList getYouTubeVideo(const QString &param, const QString &url, IOController<YouTubeDL> &youTubeDL);
 
@@ -140,7 +158,7 @@ private:
     QString lastTitle;
     QCompleter *completer;
 
-    QPointer<NetworkReply> autocompleteReply, searchReply, continuationReply;
+    QPointer<NetworkReply> autocompleteReply, searchReply, continuationReply, relatedReply;
     QList<NetworkReply *> linkReplies, imageReplies;
     NetworkAccess net;
 


### PR DESCRIPTION
Adds a feature to load related items of a YT video. New context menu entry "Show related" loads related items for the selected item. ("Show related" is not available for playlists.)

Hi Błażej,

I found this feature quite useful in other players (mostly NewPipe, but also the defunct Tomahawk player) and thought I'd give it a try. The implementation is more of a quick hack, mostly mirroring existing functionality and structure. It's probably not written very nicely, so you might want to review and comment. If you have specific comments or requests, I'll be happy to make changes. If you think this feature is not useful for QMPlay2, that's fine as well.

Cheers,
Johann