### PR TITLE
Update openSUSE Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ Table of Contents
 #### Easy installation on openSUSE
 - Don't mix FFmpeg from different repositories!
 - Run the following commands:
-##### openSUSE Leap 15.2
+##### openSUSE Leap 15.3
 ```
-sudo zypper ar http://packman.inode.at/suse/openSUSE_Leap_15.2 Packman
-sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
-sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Leap_15.2
-sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.2
+sudo zypper ar https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Leap_15.3 Packman
+sudo zypper ar http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.3
+sudo zypper dup --allow-vendor-change --from "Packman"
+sudo zypper dup --allow-vendor-change --from http://download.opensuse.org/repositories/multimedia:/apps/openSUSE_Leap_15.3
 sudo zypper in QMPlay2
 ```
 ##### openSUSE Tumbleweed
 ```
-sudo zypper ar http://packman.inode.at/suse/openSUSE_Tumbleweed Packman
-sudo zypper dup --allow-vendor-change --from http://packman.inode.at/suse/openSUSE_Tumbleweed
+sudo zypper ar https://ftp.gwdg.de/pub/linux/misc/packman/suse/openSUSE_Tumbleweed Packman
+sudo zypper dup --allow-vendor-change --from "Packman"
 sudo zypper in QMPlay2
 ```
 #### Easy installation on Fedora


### PR DESCRIPTION
- The Packman mirror http://packman.inode.at/ is dead, use https://ftp.gwdg.de instead. This one also supports HTTPS encryption.
- Switch from Leap 15.2 to 15.3 since 15.2 is nearing EOL now.
- Shorten the zypper dup command to use the Packman repo name instead of full URL.