### PR TITLE
Changed Left Button to Primary Button

### DIFF
--- a/lang/de.ts
+++ b/lang/de.ts
@@ -2269,8 +2269,8 @@
         <translation>Mausrad ändert die Lautstärke</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Linke Maustaste auf Video-Dock schaltet die Wiedergabe um</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Linke Maustaste auf Video-Dock schaltet die Wiedergabe um</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/es.ts
+++ b/lang/es.ts
@@ -2270,8 +2270,8 @@
         <translation>La rueda del ratón cambia el volumen</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>El botón izquierdo del ratón sobre el vídeo alterna pausa/reprodución</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">El botón izquierdo del ratón sobre el vídeo alterna pausa/reprodución</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/fr.ts
+++ b/lang/fr.ts
@@ -2267,7 +2267,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
+        <source>Primary mouse button on video dock toggles playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/hu.ts
+++ b/lang/hu.ts
@@ -2270,8 +2270,8 @@
         <translation>Hang lekeverése</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Bal egérgomb a video dokkon megállítja/elindítja a lejátszást</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Bal egérgomb a video dokkon megállítja/elindítja a lejátszást</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/ja.ts
+++ b/lang/ja.ts
@@ -2272,8 +2272,8 @@
         <translation>マウスホイールで音量を変える</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>マウスがビデオドックから出たら停止する</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">マウスがビデオドックから出たら停止する</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/nl.ts
+++ b/lang/nl.ts
@@ -2171,7 +2171,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
+        <source>Primary mouse button on video dock toggles playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/pl.ts
+++ b/lang/pl.ts
@@ -2270,8 +2270,8 @@
         <translation>Wzmocnienie</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Lewy przycisk myszy w oknie wideo przełącza odtwarzanie</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Lewy przycisk myszy w oknie wideo przełącza odtwarzanie</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/pt_BR.ts
+++ b/lang/pt_BR.ts
@@ -2179,8 +2179,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Botão esquerdo do mouse na dock de vídeo alterna a reprodução</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Botão esquerdo do mouse na dock de vídeo alterna a reprodução</translation>
     </message>
     <message>
         <source>Middle mouse button on video dock toggles fullscreen</source>

--- a/lang/ru.ts
+++ b/lang/ru.ts
@@ -2267,8 +2267,8 @@
         <translation>Усиление</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Левая кнопка мыши на видео панели переключает воспроизведен</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Левая кнопка мыши на видео панели переключает воспроизведен</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/sk.ts
+++ b/lang/sk.ts
@@ -2270,8 +2270,8 @@
         <translation>Zosilnenie</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Ľavé tlačidlo v okne videa vypína/zapína prehrávanie</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Ľavé tlačidlo v okne videa vypína/zapína prehrávanie</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/uk.ts
+++ b/lang/uk.ts
@@ -2270,8 +2270,8 @@
         <translation>Посилення</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>Ліва кнопка миші у вікні відео перемикає відтворення</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation type="obsolete">Ліва кнопка миші у вікні відео перемикає відтворення</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/zh_CN.ts
+++ b/lang/zh_CN.ts
@@ -2270,8 +2270,8 @@
         <translation>鼠标滚轮更改音量</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>鼠标左键点击视频切换回放</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation>鼠标主键点击视频切换回放</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/lang/zh_TW.ts
+++ b/lang/zh_TW.ts
@@ -2270,8 +2270,8 @@
         <translation>滑鼠滾輪改變音量</translation>
     </message>
     <message>
-        <source>Left mouse button on video dock toggles playback</source>
-        <translation>在視訊泊位按滑鼠左鍵改變播放狀態</translation>
+        <source>Primary mouse button on video dock toggles playback</source>
+        <translation>在視訊泊位按滑鼠主鍵改變播放狀態</translation>
     </message>
     <message>
         <source>Accurate seeking</source>

--- a/src/gui/Ui/SettingsPlayback.ui
+++ b/src/gui/Ui/SettingsPlayback.ui
@@ -116,7 +116,7 @@
           <string>Partially checked means that there is a delay between click and pausing</string>
          </property>
          <property name="text">
-          <string>Left mouse button on video dock toggles playback</string>
+          <string>Primary mouse button on video dock toggles playback</string>
          </property>
          <property name="tristate">
           <bool>true</bool>


### PR DESCRIPTION
The left button is not necessarily the primary one. "Primary" is more appropriate.