### PR TITLE
Port to ffmpeg 5.0

### DIFF
--- a/src/modules/CUVID/CuvidDec.cpp
+++ b/src/modules/CUVID/CuvidDec.cpp
@@ -431,7 +431,7 @@ bool CuvidDec::open(StreamInfo &streamInfo)
     if (streamInfo.codec_type != AVMEDIA_TYPE_VIDEO)
         return false;
 
-    AVCodec *avCodec = avcodec_find_decoder_by_name(streamInfo.codec_name);
+    const AVCodec *avCodec = avcodec_find_decoder_by_name(streamInfo.codec_name);
     if (!avCodec)
         return false;
 

--- a/src/modules/CUVID/CuvidDec.hpp
+++ b/src/modules/CUVID/CuvidDec.hpp
@@ -26,6 +26,10 @@
 #include <QCoreApplication>
 #include <QQueue>
 
+extern "C" {
+#include <libavcodec/bsf.h>
+}
+
 class CuvidHWInterop;
 class VideoWriter;
 

--- a/src/modules/FFmpeg/FFDec.cpp
+++ b/src/modules/FFmpeg/FFDec.cpp
@@ -68,9 +68,9 @@ void FFDec::clearFrames()
 }
 
 
-AVCodec *FFDec::init(StreamInfo &streamInfo)
+const AVCodec *FFDec::init(StreamInfo &streamInfo)
 {
-    AVCodec *codec = avcodec_find_decoder_by_name(streamInfo.codec_name);
+    const AVCodec *codec = avcodec_find_decoder_by_name(streamInfo.codec_name);
     if (codec)
     {
         codec_ctx = avcodec_alloc_context3(codec);
@@ -79,7 +79,7 @@ AVCodec *FFDec::init(StreamInfo &streamInfo)
     }
     return codec;
 }
-bool FFDec::openCodec(AVCodec *codec)
+bool FFDec::openCodec(const AVCodec *codec)
 {
     if (avcodec_open2(codec_ctx, codec, nullptr))
         return false;

--- a/src/modules/FFmpeg/FFDec.hpp
+++ b/src/modules/FFmpeg/FFDec.hpp
@@ -48,8 +48,8 @@ protected:
 
     void clearFrames();
 
-    AVCodec *init(StreamInfo &streamInfo);
-    bool openCodec(AVCodec *codec);
+    const AVCodec *init(StreamInfo &streamInfo);
+    bool openCodec(const AVCodec *codec);
 
     void decodeFirstStep(const Packet &encodedPacket, bool flush);
     int decodeStep(bool &frameFinished);

--- a/src/modules/FFmpeg/FFDecSW.cpp
+++ b/src/modules/FFmpeg/FFDecSW.cpp
@@ -394,7 +394,7 @@ bool FFDecSW::decodeSubtitle(const QVector<Packet> &encodedPackets, double pos, 
 
 bool FFDecSW::open(StreamInfo &streamInfo)
 {
-    AVCodec *codec = FFDec::init(streamInfo);
+    const AVCodec *codec = FFDec::init(streamInfo);
     if (!codec)
         return false;
     if (codec_ctx->codec_type == AVMEDIA_TYPE_VIDEO)

--- a/src/modules/FFmpeg/FFDecVAAPI.cpp
+++ b/src/modules/FFmpeg/FFDecVAAPI.cpp
@@ -186,7 +186,7 @@ bool FFDecVAAPI::open(StreamInfo &streamInfo)
         return false;
     }
 
-    AVCodec *codec = init(streamInfo);
+    const AVCodec *codec = init(streamInfo);
     if (!codec || !hasHWAccel("vaapi"))
         return false;
 

--- a/src/modules/FFmpeg/FFDecVDPAU.cpp
+++ b/src/modules/FFmpeg/FFDecVDPAU.cpp
@@ -144,7 +144,7 @@ bool FFDecVDPAU::open(StreamInfo &streamInfo)
     if (pix_fmt != AV_PIX_FMT_YUV420P && pix_fmt != AV_PIX_FMT_YUVJ420P)
         return false;
 
-    AVCodec *codec = init(streamInfo);
+    const AVCodec *codec = init(streamInfo);
     if (!codec || !hasHWAccel("vdpau"))
         return false;
 

--- a/src/modules/FFmpeg/FormatContext.cpp
+++ b/src/modules/FFmpeg/FormatContext.cpp
@@ -168,10 +168,10 @@ private:
 class OpenFmtCtxThr : public OpenThr
 {
     AVFormatContext *m_formatCtx;
-    AVInputFormat *m_inputFmt;
+    const AVInputFormat *m_inputFmt;
 
 public:
-    inline OpenFmtCtxThr(AVFormatContext *formatCtx, const QByteArray &url, AVInputFormat *inputFmt, AVDictionary *options, std::shared_ptr<AbortContext> &abortCtx) :
+    inline OpenFmtCtxThr(AVFormatContext *formatCtx, const QByteArray &url, const AVInputFormat *inputFmt, AVDictionary *options, std::shared_ptr<AbortContext> &abortCtx) :
         OpenThr(url, options, abortCtx),
         m_formatCtx(formatCtx),
         m_inputFmt(inputFmt)
@@ -679,7 +679,7 @@ bool FormatContext::open(const QString &_url, const QString &param)
             return false;
     }
 
-    AVInputFormat *inputFmt = nullptr;
+    const AVInputFormat *inputFmt = nullptr;
     if (scheme == "file")
         isLocal = true;
     else


### PR DESCRIPTION
Make QMPlay2 compile and work with ffmpeg 5.0
Mostly a matter of more const-ness and a missing
include.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>