### PR TITLE
show the YouTube video description in the Info panel

### DIFF
--- a/src/gui/DemuxerThr.cpp
+++ b/src/gui/DemuxerThr.cpp
@@ -28,6 +28,7 @@
 #include <Demuxer.hpp>
 #include <Decoder.hpp>
 #include <Reader.hpp>
+#include <YouTubeDL.hpp>
 
 #include <QCryptographicHash>
 #include <QCoreApplication>
@@ -792,6 +793,7 @@ void DemuxerThr::addSubtitleStream(bool currentPlaying, QString &subtitlesStream
         streamMenuText.push_back(" - " + title);
     addStreamsMenuString(streamsMenu, streamCountStr, streamLink, currentPlaying, streamMenuText);
 }
+
 void DemuxerThr::emitInfo()
 {
     QString info;
@@ -857,6 +859,19 @@ void DemuxerThr::emitInfo()
     if (demuxer->bitrate() > 0)
         info += "<b>" + tr("Bitrate") + ":</b> " + QString::number(demuxer->bitrate()) + "kbps<br/>";
     info += "<b>" + tr("Format") + ":</b> " + demuxer->name();
+    //description
+    auto youTubeDL = ioCtrl.toPtr<YouTubeDL>();
+    if (youTubeDL && *youTubeDL) {
+        auto desc = (*youTubeDL)->description().split("\n");
+        if (!desc.isEmpty()) {
+            auto line = desc.takeFirst();
+            info += "<br><b>" + tr("Description") + ":</b> " + line;
+            while (!desc.isEmpty()) {
+                line = desc.takeFirst();
+                info += "<br>&nbsp;&nbsp;" + line;
+            }
+        }
+    }
 
     if (!demuxer->image().isNull())
         info += "<br/><br/><a href='save_cover'>" + tr("Save cover picture") + "</a>";

--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -462,7 +462,7 @@ void YouTube::convertAddress(const QString &prefix, const QString &url, const QS
                 if (extension)
                     *extension = youTubeVideo[1];
             }
-            youTubeDl.reset();
+//             youTubeDl.reset();
         }
     }
     else if (prefix == "youtube-dl")
@@ -1287,6 +1287,11 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
         result += ext;
     }
     result += title;
+
+    const auto description = o["description"];
+    if (description != QJsonValue::Undefined) {
+        youTubeDL->setDescription(o["description"].toString());
+    }
 
     return result;
 }

--- a/src/qmplay2/YouTubeDL.cpp
+++ b/src/qmplay2/YouTubeDL.cpp
@@ -454,3 +454,13 @@ void YouTubeDL::startProcess(QStringList args)
 
     m_process.start(program, args);
 }
+
+void YouTubeDL::setDescription(const QString &desc)
+{
+    m_description = desc;
+}
+
+const QString YouTubeDL::description()
+{
+    return m_description;
+}

--- a/src/qmplay2/YouTubeDL.hpp
+++ b/src/qmplay2/YouTubeDL.hpp
@@ -44,6 +44,8 @@ public:
 
     QStringList exec(const QString &url, const QStringList &args, QString *silentErr = nullptr, bool rawOutput = false);
 
+    void setDescription(const QString &desc);
+    const QString description();
 private:
     void abort() override;
 
@@ -65,4 +67,5 @@ private:
     IOController<NetworkReply> m_reply;
     QProcess m_process;
     bool m_aborted;
+    QString m_description;
 };


### PR DESCRIPTION
This is a proof-of-concept implementation for showing the description of YouTube videos in QMPlay2's Info panel.

The information is communicated via the YouTubeDL class instance, which required NOT doing the reset of the local instance in `YouTube::convertAddress()` (otherwise, `DemuxerThr::addSubtitleStream()` will see a NULL instance, hence the double check). There appears to be no side-effect of doing that (even with the reset, the instance is deleted only when the application exits).

A more proper implementation would probably use a dedicated class for storing metadata, including name, title etc. - rather than passing those around via function arguments. That however requires a much larger overhaul than I feel confident to handle ATM.

Fixes #465
