### PR TITLE
Do not attempt to use VTB for VP9 decoding when not supported

### DIFF
--- a/src/modules/FFmpeg/FFDecVTB.cpp
+++ b/src/modules/FFmpeg/FFDecVTB.cpp
@@ -75,7 +75,16 @@ bool FFDecVTB::open(StreamInfo &streamInfo)
 {
     if (streamInfo.params->codec_type != AVMEDIA_TYPE_VIDEO)
         return false;
-
+    if (streamInfo.params->codec_id == AV_CODEC_ID_VP9)
+    {
+#if __has_builtin(__builtin_available)
+        if (! __builtin_available(macOS 10.15, *))
+#endif
+        {
+            qWarning() << "VP9 not supported by VTB";
+            return false;
+        }
+    }
     const AVPixelFormat pix_fmt = streamInfo.pixelFormat();
     if (pix_fmt == AV_PIX_FMT_YUV420P10)
     {

--- a/src/modules/FFmpeg/FFDecVTB.cpp
+++ b/src/modules/FFmpeg/FFDecVTB.cpp
@@ -34,9 +34,60 @@ extern "C"
     #include <libavcodec/avcodec.h>
     #include <libavutil/hwcontext.h>
     #include <libavutil/hwcontext_videotoolbox.h>
+    #include <libavcodec/videotoolbox.h>
 }
 
+#include <dlfcn.h>
+
 using namespace std;
+
+static bool isCodecSupported(const StreamInfo &streamInfo) // Put this above "vtbGetFormat"
+{
+    CMVideoCodecType cmCType;
+    switch (streamInfo.params->codec_id)
+    {
+        case AV_CODEC_ID_H263:
+            cmCType = kCMVideoCodecType_H263;
+            break;
+        case AV_CODEC_ID_H264:
+            cmCType = kCMVideoCodecType_H264;
+            break;
+        case AV_CODEC_ID_HEVC:
+            // kCMVideoCodecType_HEVC isn't defined on all Mac OS versions
+            cmCType = 'hvc1';
+            break;
+        case AV_CODEC_ID_MPEG1VIDEO:
+            cmCType = kCMVideoCodecType_MPEG1Video;
+            break;
+        case AV_CODEC_ID_MPEG2VIDEO:
+            cmCType = kCMVideoCodecType_MPEG2Video;
+            break;
+        case AV_CODEC_ID_MPEG4:
+            cmCType = kCMVideoCodecType_MPEG4Video;
+            break;
+        case AV_CODEC_ID_VP9:
+            // kCMVideoCodecType_VP9 isn't defined on all Mac OS versions
+            cmCType = 'vp09';
+            break;
+        default:
+            cmCType = 0;
+            break;
+    }
+
+    if (!cmCType)
+        return false;
+
+    // VTIsHardwareDecodeSupported() was introduced in 10.13 only so in order to run on older OS versions
+    // without resorting to conditional code we obtain (and cache) a pointer to the function via dlsym().
+    // According to https://www.objc.io/issues/23-video/videotoolbox/ Macs (running OS X 10.10) support
+    // "usually both H.264 and MPEG-4 Part 2 in hardware". H263 and MPEG 1,2 are supported in software
+    // which is of no use for us here.
+    static auto VTIsHardwareDecodeSupported = (bool (*)(CMVideoCodecType))dlsym(RTLD_DEFAULT, "VTIsHardwareDecodeSupported");
+    return VTIsHardwareDecodeSupported 
+        ? VTIsHardwareDecodeSupported(cmCType)
+        : (cmCType == kCMVideoCodecType_H264 || cmCType == kCMVideoCodecType_MPEG4Video)
+    ;
+}
 
 static AVPixelFormat vtbGetFormat(AVCodecContext *codecCtx, const AVPixelFormat *pixFmt)
 {
@@ -73,18 +124,9 @@ QString FFDecVTB::name() const
 
 bool FFDecVTB::open(StreamInfo &streamInfo)
 {
-    if (streamInfo.params->codec_type != AVMEDIA_TYPE_VIDEO)
+    if (streamInfo.params->codec_type != AVMEDIA_TYPE_VIDEO || !hasHWAccel("videotoolbox"))
         return false;
-    if (streamInfo.params->codec_id == AV_CODEC_ID_VP9)
-    {
-#if __has_builtin(__builtin_available)
-        if (! __builtin_available(macOS 10.15, *))
-#endif
-        {
-            qWarning() << "VP9 not supported by VTB";
-            return false;
-        }
-    }
+
     const AVPixelFormat pix_fmt = streamInfo.pixelFormat();
     if (pix_fmt == AV_PIX_FMT_YUV420P10)
     {
@@ -95,10 +137,19 @@ bool FFDecVTB::open(StreamInfo &streamInfo)
     {
         return false;
     }
+    
+    if (!isCodecSupported(streamInfo))
+    {
+        qWarning() << streamInfo.codec_name << "is not supported by VTB";
+        return false;
+    }
 
     AVCodec *codec = init(streamInfo);
-    if (!codec || !hasHWAccel("videotoolbox"))
+    if (!codec)
+    {
+        qWarning() << "VTB: no or unsupported codec";
         return false;
+    }
 
 #ifdef USE_OPENGL
     shared_ptr<VTBOpenGL> vtbOpenGL;
@@ -112,14 +163,20 @@ bool FFDecVTB::open(StreamInfo &streamInfo)
 #endif
 
     if (!m_hwDeviceBufferRef && av_hwdevice_ctx_create(&m_hwDeviceBufferRef, AV_HWDEVICE_TYPE_VIDEOTOOLBOX, nullptr, nullptr, 0) != 0)
+    {
+        qWarning() << "VTB: failed to create hwdevice_ctx";
         return false;
+    }
 
 #ifdef USE_OPENGL
     if (QMPlay2Core.renderer() == QMPlay2CoreClass::Renderer::OpenGL && !vtbOpenGL)
     {
         vtbOpenGL = make_shared<VTBOpenGL>(m_hwDeviceBufferRef);
         if (!QMPlay2Core.gpuInstance()->setHWDecContextForVideoOutput(vtbOpenGL))
+        {
+            qWarning() << "VTB: failed to set VTB GPU context";
             return false;
+        }
     }
 
     if (vtbOpenGL)
@@ -130,7 +187,10 @@ bool FFDecVTB::open(StreamInfo &streamInfo)
     codec_ctx->get_format = vtbGetFormat;
     codec_ctx->thread_count = 1;
     if (!openCodec(codec))
+    {
+        qWarning() << "VTB: failed to open codec";
         return false;
+    }
 
     m_timeBase = streamInfo.time_base;
     return true;


### PR DESCRIPTION
The VideoToolBox framework on Mac gained support for VP9 decoding somewhere in 2018, most likely with the release of Mac OS 10.15 . Only allow VTB hw-accelerated decoding of VP9 content from that OS version onwards.

QMPlay2 no longer crashes without this protection (since https://github.com/zaps166/QMPlay2/issues/610#issuecomment-1579349256?); instead there is a visible reset and most of the information in the `Information` window disappears.

NB: working VTB acceleration still requires building with default (public) C++ visibibility (or merging the FFmpeg extension into libqmplay2).