### PR TITLE
Make classes required for VideoToolBox support visible across modules

### DIFF
--- a/src/modules/FFmpeg/CMakeLists.txt
+++ b/src/modules/FFmpeg/CMakeLists.txt
@@ -127,6 +127,8 @@ if(USE_FFMPEG_VAAPI OR USE_FFMPEG_VDPAU OR USE_FFMPEG_DXVA2 OR USE_FFMPEG_D3D11V
     endif()
 endif()
 
+add_definitions(-DFFMPEG_MODULE)
+
 add_library(${PROJECT_NAME} ${QMPLAY2_MODULE}
     ${FFmpeg_HDR}
     ${FFmpeg_SRC}

--- a/src/modules/FFmpeg/FFDec.hpp
+++ b/src/modules/FFmpeg/FFDec.hpp
@@ -23,6 +23,14 @@
 #include <QString>
 #include <QList>
 
+#include <QtGlobal>
+
+#if defined(FFMPEG_MODULE)
+    #define FFMPEGVTB_EXPORT Q_DECL_EXPORT
+#else
+    #define FFMPEGVTB_EXPORT Q_DECL_IMPORT
+#endif
+
 #ifdef USE_VULKAN
 namespace QmVk {
 class ImagePool;
@@ -34,7 +42,7 @@ struct AVPacket;
 struct AVCodec;
 struct AVFrame;
 
-class FFDec : public Decoder
+class FFMPEGVTB_EXPORT FFDec : public Decoder
 {
 protected:
     FFDec();

--- a/src/modules/FFmpeg/FFDecHWAccel.hpp
+++ b/src/modules/FFmpeg/FFDecHWAccel.hpp
@@ -20,7 +20,7 @@
 
 #include <FFDec.hpp>
 
-class FFDecHWAccel : public FFDec
+class FFMPEGVTB_EXPORT FFDecHWAccel : public FFDec
 {
 protected:
     FFDecHWAccel();

--- a/src/modules/FFmpeg/FFDecSW.hpp
+++ b/src/modules/FFmpeg/FFDecSW.hpp
@@ -49,7 +49,7 @@ public:
 
 struct SwsContext;
 
-class FFDecSW final : public FFDec
+class FFMPEGVTB_EXPORT FFDecSW final : public FFDec
 {
 public:
     FFDecSW(Module &);

--- a/src/modules/FFmpeg/FFDecVTB.hpp
+++ b/src/modules/FFmpeg/FFDecVTB.hpp
@@ -20,7 +20,7 @@
 
 #include <FFDecHWAccel.hpp>
 
-class FFDecVTB final : public FFDecHWAccel
+class FFMPEGVTB_EXPORT FFDecVTB final : public FFDecHWAccel
 {
 public:
     FFDecVTB(Module &module);

--- a/src/qmplay2/opengl/OpenGLHWInterop.hpp
+++ b/src/qmplay2/opengl/OpenGLHWInterop.hpp
@@ -25,7 +25,7 @@
 
 class ImgScaler;
 
-class OpenGLHWInterop : public HWDecContext
+class QMPLAY2SHAREDLIB_EXPORT OpenGLHWInterop : public HWDecContext
 {
 public:
     enum Format


### PR DESCRIPTION
VideoToolBox support failed on certain older Mac OS X versions because hidden visibility caused a dynamic cast from a FFDecVTB instance to fail. This issue is fixed by exporting the classes involved.

Fixes #610