### PR TITLE
let QMPlay2 handle youtube:XXYYZZ URIs

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -221,7 +221,8 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME} Qt5::WinExtras winmm)
 elseif(APPLE)
     set_target_properties(${PROJECT_NAME} PROPERTIES
-        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macOS/BundleInfo.plist.in")
+        MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macOS/BundleInfo.plist.in"
+        MACOSX_BUNDLE_GUI_IDENTIFIER "org.zaps166.${PROJECT_NAME}")
     target_link_libraries(${PROJECT_NAME} ${APPKIT_LIBRARY} ${IOKIT_LIBRARY})
 endif()
 if(USE_TAGLIB AND (NOT WIN32 OR CMAKE_HOST_WIN32))

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -287,7 +287,7 @@ static QCommandLineParser *createCmdParser(bool descriptions)
 }
 static QString fileArg(const QString &arg)
 {
-    if (!arg.contains("://"))
+    if (!arg.contains("://") && !arg.startsWith("youtube:"))
     {
         const QFileInfo argInfo(arg);
         if (!argInfo.isAbsolute())

--- a/src/gui/MainWidget.cpp
+++ b/src/gui/MainWidget.cpp
@@ -2035,7 +2035,9 @@ bool MainWidget::eventFilter(QObject *obj, QEvent *event)
 #ifdef Q_OS_MACOS
     else if (event->type() == QEvent::FileOpen)
     {
-        filesToAdd.append(((QFileOpenEvent *)event)->file());
+        auto url = ((QFileOpenEvent *)event)->url();
+        filesToAdd.append(url.scheme() == "file" ? ((QFileOpenEvent *)event)->file()
+            : Functions::maybeExtensionAddress(url.url()));
         fileOpenTimer.start(10);
     }
 #endif

--- a/src/gui/Unix/QMPlay2_youtube.desktop
+++ b/src/gui/Unix/QMPlay2_youtube.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Exec=QMPlay2 --show %u
+Icon=QMPlay2
+Name=Play youtube:VID URI in QMPlay2
+StartupNotify=false
+Type=Application
+Categories=Qt;AudioVideo;Player;Audio;Video;
+MimeType=x-scheme-handler/youtube;
+NoDisplay=true

--- a/src/gui/macOS/BundleInfo.plist.in
+++ b/src/gui/macOS/BundleInfo.plist.in
@@ -111,6 +111,17 @@
             <string>Viewer</string>
         </dict>
     </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>YouTube video ID</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>youtube</string>
+            </array>
+        </dict>
+    </array>
     <key>CFBundleDevelopmentRegion</key>
     <string>English</string>
     <key>CFBundleExecutable</key>


### PR DESCRIPTION
There are times where I want to refer to a YouTube video in shorthand notation that isn't usually recognised as "direct link" (e.g. on discussion forums where direct linking to videos with specific content isn't allowed). The obvious choice is `youtube:XXYYZZ` where `XXYYZZ` is the video identifier.

This patch enables QMPlay2 to process such URIs.

(This PR is a bit for fun and/or just-in-case)