### PR TITLE
FormatContext: Use textWithFallbackEncoding in getTag

### DIFF
--- a/src/gui/Ui/SettingsGeneral.ui
+++ b/src/gui/Ui/SettingsGeneral.ui
@@ -144,7 +144,7 @@
          <item row="2" column="0">
           <widget class="QLabel" name="encodingL">
            <property name="text">
-            <string>Subtitles encoding</string>
+            <string>Subtitles and tags encoding</string>
            </property>
           </widget>
          </item>

--- a/src/modules/FFmpeg/FormatContext.cpp
+++ b/src/modules/FFmpeg/FormatContext.cpp
@@ -80,7 +80,7 @@ static QByteArray getTag(AVDictionary *metadata, const char *key, const bool ded
     AVDictionaryEntry *avTag = av_dict_get(metadata, key, nullptr, 0);
     if (avTag && avTag->value)
     {
-        const QByteArray tag = QByteArray(avTag->value);
+        const QByteArray tag = Functions::textWithFallbackEncoding(QByteArray(avTag->value));
         if (deduplicate)
         {
             // Workaround for duplicated tags separated by ';'.


### PR DESCRIPTION
Hello,
Please consider this pull request.

_**Current behaivor:**_
QMPlay2 currently converts QByteArray to QString "directly" in FormatContext after calling getTag, but tags in metadata can be any encoding and direct conversion may produce incorrect results (e.g. windows-1252).

_**Possible solution:**_
Use textWithFallbackEncoding the same as you use for subtitles, but this requires more manual settings by the user and what worked automatically may break, for example, GB18030 converts well directly from QByteArray to QString.

You can merge this change and improve or reject it, but it seems to me that the current behavior needs to be changed.
Thanks.