### PR TITLE
Mark error logs untranslatable

### DIFF
--- a/src/gui/AudioThr.cpp
+++ b/src/gui/AudioThr.cpp
@@ -95,10 +95,10 @@ bool AudioThr::setParams(uchar realChn, uint realSRate, uchar chn, uint sRate, b
             channels = writer->getParam("chn").toUInt();
             sample_rate = writer->getParam("rate").toUInt();
             if ((!chn || channels == lastChn) && (!sRate || sample_rate == lastSRate))
-                QMPlay2Core.logInfo(tr("Module") + " \"" + writer->name() + "\" " + tr("sets the parameters to") + ": " + QString::number(channels) + " " + tr("channels") + ", " + QString::number(sample_rate) + " " + tr("Hz"));
+                QMPlay2Core.logInfo("Module \"" + writer->name() + "\" sets the parameters to: " + QString::number(channels) + " channels, " + QString::number(sample_rate) + " Hz");
             else
             {
-                QMPlay2Core.logError(tr("Module") + " \"" + writer->name() + "\" " + tr("requires a change in one of the forced parameters, sound disabled ..."));
+                QMPlay2Core.logError("Modul \"" + writer->name() + "\" requires a change in one of the forced parameters, sound disabled...");
                 return false;
             }
         }
@@ -451,7 +451,7 @@ bool AudioThr::createResampler(bool cleanBuffers)
 
         const bool OK = sndResampler.create(realSample_rate, realChannels, sample_rate, channels, speed, m_lastKeepAudioPitch);
         if (!OK)
-            QMPlay2Core.logError(tr("Error during initialization") + ": " + sndResampler.name());
+            QMPlay2Core.logError(QString("Error during initialization:") + sndResampler.name());
         return OK;
     }
     sndResampler.destroy();

--- a/src/gui/DemuxerThr.cpp
+++ b/src/gui/DemuxerThr.cpp
@@ -354,7 +354,7 @@ void DemuxerThr::run()
     {
         if (!demuxer.isAborted() && !demuxer)
         {
-            QMPlay2Core.logError(tr("Cannot open") + ": " + url.remove("file://"));
+            QMPlay2Core.logError("Cannot open: " + url.remove("file://"));
             emit playC.updateCurrentEntry(QString(), -1.0);
             err = true;
         }

--- a/src/gui/VideoThr.cpp
+++ b/src/gui/VideoThr.cpp
@@ -261,7 +261,7 @@ void VideoThr::initFilters()
                             filters.off(filter);
                     }
                     if (!ok && W > 0 && H > 0)
-                        QMPlay2Core.logError(tr("Error initializing filter") + " \"" + filterName + '"');
+                        QMPlay2Core.logError("Error initializing filter \"" + filterName + '"');
                 }
             }
         };
@@ -313,7 +313,7 @@ void VideoThr::initFilters()
                     {
                         filters.off(deintFilter);
                         if (W > 0 && H > 0)
-                            QMPlay2Core.logError(tr("Cannot initialize the deinterlacing filter") + " \"" + deintFilterName + '"', true, true);
+                            QMPlay2Core.logError("Cannot initialize the deinterlacing filter \"" + deintFilterName + '"', true, true);
                     }
                 }
             }
@@ -880,7 +880,7 @@ void VideoThr::screenshot(Frame videoFrame)
 
     if (img.isNull())
     {
-        QMPlay2Core.logError(tr("Cannot create screenshot"));
+        QMPlay2Core.logError("Cannot create screenshot");
         return;
     }
 

--- a/src/modules/ALSA/ALSAWriter.cpp
+++ b/src/modules/ALSA/ALSAWriter.cpp
@@ -172,7 +172,7 @@ bool ALSAWriter::processParams(bool *paramsCorrected)
                 else
                 {
                     sndOpen = !snd_pcm_open(&snd, devName.toLocal8Bit(), SND_PCM_STREAM_PLAYBACK, 0);
-                    QMPlay2Core.logInfo("ALSA :: " + tr("Cannot open") + " \"" + chosenDevName + "\", " + tr("back to") + " \"" + devName + "\"");
+                    QMPlay2Core.logInfo("ALSA :: Cannot open \"" + chosenDevName + "\", back to \"" + devName + '"');
                 }
             }
             if (sndOpen)
@@ -259,7 +259,7 @@ bool ALSAWriter::processParams(bool *paramsCorrected)
             }
         }
         err = true;
-        QMPlay2Core.logError("ALSA :: " + tr("Cannot open audio output stream"));
+        QMPlay2Core.logError("ALSA :: Cannot open audio output stream");
     }
 
     return readyWrite();
@@ -309,7 +309,7 @@ qint64 ALSAWriter::write(const QByteArray &arr)
     int ret = snd_pcm_writei(snd, int_samples.constData(), to_write);
     if (ret < 0 && ret != -EPIPE && snd_pcm_recover(snd, ret, false))
     {
-        QMPlay2Core.logError("ALSA :: " + tr("Playback error"));
+        QMPlay2Core.logError("ALSA :: Playback error");
         err = true;
         return 0;
     }

--- a/src/modules/AudioCD/AudioCDDemux.cpp
+++ b/src/modules/AudioCD/AudioCDDemux.cpp
@@ -263,13 +263,13 @@ bool AudioCDDemux::open(const QString &_url)
                     return true;
                 }
                 else
-                    QMPlay2Core.log(tr("Error reading track"));
+                    QMPlay2Core.log("Error reading track");
             }
             else
-                QMPlay2Core.log(tr("No CD"));
+                QMPlay2Core.log("No CD");
         }
         else
-            QMPlay2Core.log(tr("Invalid path to CD drive"));
+            QMPlay2Core.log("Invalid path to CD drive");
     }
     return false;
 }
@@ -282,7 +282,7 @@ Playlist::Entries AudioCDDemux::fetchTracks(const QString &url, bool &ok)
         const QString realUrl = url.mid(strlen(AudioCDName) + 3);
         entries = getTracks(realUrl);
         if (entries.isEmpty())
-            emit QMPlay2Core.sendMessage(tr("No AudioCD found!"), AudioCDName, 2, 0);
+            emit QMPlay2Core.sendMessage("No AudioCD found!", AudioCDName, 2, 0);
         else
         {
             for (int i = 0; i < entries.count(); ++i)

--- a/src/modules/Extensions/LastFM.cpp
+++ b/src/modules/Extensions/LastFM.cpp
@@ -322,7 +322,7 @@ void LastFM::loginFinished()
     {
         const bool wrongLoginOrPassword = (loginReply->error() == NetworkReply::Error::Connection403);
         if (!dontShowLoginError || wrongLoginOrPassword)
-            QMPlay2Core.logError(tr("LastFM login error.") + (wrongLoginOrPassword ? (" " + tr("Check login and password!")) : QString()));
+            QMPlay2Core.logError("LastFM login error." + (wrongLoginOrPassword ? ("Check login and password!") : QString()));
         if (wrongLoginOrPassword)
             clear();
         else
@@ -341,7 +341,7 @@ void LastFM::loginFinished()
             if (end_idx > -1)
             {
                 session_key = reply.mid(idx, end_idx - idx);
-                QMPlay2Core.log(tr("Logged in to LastFM!"), InfoLog);
+                QMPlay2Core.log("Logged in to LastFM!", InfoLog);
                 if (!scrobbleQueue.isEmpty() && !updateTim.isActive())
                     updateTim.start(scrobbleSec * 1000);
                 dontShowLoginError = false;

--- a/src/modules/FFmpeg/VAAPI.cpp
+++ b/src/modules/FFmpeg/VAAPI.cpp
@@ -239,17 +239,17 @@ void VAAPI::maybeInitVPP(int surfaceW, int surfaceH)
                         }
                         if (vpp_deint_type == VAProcDeinterlacingMotionCompensated && !vpp_deint_types[2])
                         {
-                            QMPlay2Core.log("VA-API :: " + tr("Unsupported deinterlacing algorithm") + " - Motion compensated", ErrorLog | LogOnce);
+                            QMPlay2Core.log("VA-API :: Unsupported deinterlacing algorithm - Motion compensated", ErrorLog | LogOnce);
                             vpp_deint_type = VAProcDeinterlacingMotionAdaptive;
                         }
                         if (vpp_deint_type == VAProcDeinterlacingMotionAdaptive && !vpp_deint_types[1])
                         {
-                            QMPlay2Core.log("VA-API :: " + tr("Unsupported deinterlacing algorithm") + " - Motion adaptive", ErrorLog | LogOnce);
+                            QMPlay2Core.log("VA-API :: Unsupported deinterlacing algorithm - Motion adaptive", ErrorLog | LogOnce);
                             vpp_deint_type = (m_fd > -1) ? VAProcDeinterlacingBob : VAProcDeinterlacingNone;
                         }
                         if (vpp_deint_type == VAProcDeinterlacingBob && !vpp_deint_types[0])
                         {
-                            QMPlay2Core.log("VA-API :: " + tr("Unsupported deinterlacing algorithm") + " - Bob", ErrorLog | LogOnce);
+                            QMPlay2Core.log("VA-API :: Unsupported deinterlacing algorithm - Bob", ErrorLog | LogOnce);
                             vpp_deint_type = VAProcDeinterlacingNone;
                         }
                         if (vpp_deint_type != VAProcDeinterlacingNone)
@@ -276,7 +276,7 @@ void VAAPI::maybeInitVPP(int surfaceW, int surfaceH)
     }
 
     if (vpp_deint_type != VAProcDeinterlacingNone) //Show error only when filter is required
-        QMPlay2Core.log("VA-API :: " + tr("Cannot open video filters"), ErrorLog | LogOnce);
+        QMPlay2Core.log("VA-API :: Cannot open video filters", ErrorLog | LogOnce);
 
     clearVPP();
 }

--- a/src/modules/FFmpeg/VDPAU.cpp
+++ b/src/modules/FFmpeg/VDPAU.cpp
@@ -477,7 +477,7 @@ void VDPAU::applyVideoMixerFeatures()
         m_sharpness / 100.0f
     );
     if (m_sharpness != 0 && !sharpness)
-        QMPlay2Core.log(tr("Unsupported image sharpness filter"), ErrorLog | LogOnce);
+        QMPlay2Core.log("Unsupported image sharpness filter", ErrorLog | LogOnce);
 
     const bool temporalDeint = setVideoMixerFeature(
         m_deintMethod == 1,
@@ -496,11 +496,11 @@ void VDPAU::applyVideoMixerFeatures()
     );
 
     if (m_deintMethod == 1 && !temporalDeint)
-        QMPlay2Core.log(tr("Unsupported deinterlacing algorithm") + " - Temporal", ErrorLog | LogOnce);
+        QMPlay2Core.log("Unsupported deinterlacing algorithm - Temporal", ErrorLog | LogOnce);
     if (m_deintMethod == 2 && !temploralSpatialDeint)
-        QMPlay2Core.log(tr("Unsupported deinterlacing algorithm") + " - Temporal-spatial", ErrorLog | LogOnce);
+        QMPlay2Core.log("Unsupported deinterlacing algorithm - Temporal-spatial", ErrorLog | LogOnce);
     if (m_nrEnabled && !nr)
-        QMPlay2Core.log(tr("Unsupported noise reduction filter"), ErrorLog | LogOnce);
+        QMPlay2Core.log("Unsupported noise reduction filter", ErrorLog | LogOnce);
 }
 
 bool VDPAU::setVideoMixerFeature(VdpBool enabled, VdpVideoMixerFeature feature, VdpVideoMixerAttribute attribute, float value)

--- a/src/modules/MediaKit/MediaKitWriter.cpp
+++ b/src/modules/MediaKit/MediaKitWriter.cpp
@@ -50,7 +50,7 @@ bool MediaKitWriter::processParams( bool * )
         if ( !err )
             modParam( "delay", player.delay );
         else
-            QMPlay2Core.logError( "MediaKitWriter :: " + tr ( "Cannot open audio output stream" ) );
+            QMPlay2Core.logError("MediaKitWriter :: Cannot open audio output stream");
     }
 
     return readyWrite();
@@ -63,7 +63,7 @@ qint64 MediaKitWriter::write( const QByteArray &arr )
     err = !player.write( arr );
     if ( err )
     {
-        QMPlay2Core.logError( "MediaKitWriter :: " + tr ( "Playback error" ) );
+        QMPlay2Core.logError("MediaKitWriter :: Playback error");
         return 0;
     }
 

--- a/src/modules/PipeWire/PipeWireWriter.cpp
+++ b/src/modules/PipeWire/PipeWireWriter.cpp
@@ -119,7 +119,7 @@ bool PipeWireWriter::processParams(bool *)
 
     if (m_err)
     {
-        QMPlay2Core.logError("PipeWire :: " + tr("Cannot open audio output stream"));
+        QMPlay2Core.logError("PipeWire :: Cannot open audio output stream");
     }
 
     return readyWrite();

--- a/src/modules/PortAudio/PortAudioWriter.cpp
+++ b/src/modules/PortAudio/PortAudioWriter.cpp
@@ -221,7 +221,7 @@ bool PortAudioWriter::processParams(bool *paramsCorrected)
         close();
         if (!openStream())
         {
-            QMPlay2Core.logError("PortAudio :: " + tr("Cannot open audio output stream"));
+            QMPlay2Core.logError("PortAudio :: Cannot open audio output stream");
             m_err = true;
         }
     }
@@ -437,7 +437,7 @@ bool PortAudioWriter::writeStream(const QByteArray &arr)
 void PortAudioWriter::playbackError()
 {
     if (!m_dontShowError)
-        QMPlay2Core.logError("PortAudio :: " + tr("Playback error"));
+        QMPlay2Core.logError("PortAudio :: Playback error");
     m_err = true;
 }
 

--- a/src/modules/PulseAudio/PulseAudioWriter.cpp
+++ b/src/modules/PulseAudio/PulseAudioWriter.cpp
@@ -72,7 +72,7 @@ bool PulseAudioWriter::processParams(bool *)
         if (!err)
             modParam("delay", pulse.delay);
         else
-            QMPlay2Core.logError("PulseAudio :: " + tr("Cannot open audio output stream"));
+            QMPlay2Core.logError("PulseAudio :: Cannot open audio output stream");
     }
 
     return readyWrite();
@@ -87,7 +87,7 @@ qint64 PulseAudioWriter::write(const QByteArray &arr)
     if (err)
     {
         if (showError)
-            QMPlay2Core.logError("PulseAudio :: " + tr("Playback error"));
+            QMPlay2Core.logError("PulseAudio :: Playback error");
         return 0;
     }
 

--- a/src/qmplay2/opengl/OpenGLCommon.cpp
+++ b/src/qmplay2/opengl/OpenGLCommon.cpp
@@ -301,7 +301,7 @@ void OpenGLCommon::initializeGL()
     }
     else
     {
-        QMPlay2Core.logError(tr("Shader compile/link error"));
+        QMPlay2Core.logError("Shader compile/link error");
         isOK = false;
         return;
     }
@@ -318,7 +318,7 @@ void OpenGLCommon::initializeGL()
     }
     else
     {
-        QMPlay2Core.logError(tr("Shader compile/link error"));
+        QMPlay2Core.logError("Shader compile/link error");
         isOK = false;
         return;
     }
@@ -391,7 +391,7 @@ void OpenGLCommon::paintGL()
                     setTextureParameters(target, texture, GL_LINEAR);
                 });
                 if (hwAccelInitError)
-                    QMPlay2Core.logError("OpenGL 2 :: " + tr("Can't init %1") .arg(m_hwInterop->name()));
+                    QMPlay2Core.logError("OpenGL 2 :: Can't init " + m_hwInterop->name());
 
                 if (numPlanes == 1)
                     m_hwInterop->setVideoAdjustment(videoAdjustment);
@@ -443,7 +443,7 @@ void OpenGLCommon::paintGL()
                 }
                 else if (m_hwInterop->hasError())
                 {
-                    QMPlay2Core.logError("OpenGL 2 :: " + m_hwInterop->name() + " " + tr("texture map error"));
+                    QMPlay2Core.logError("OpenGL 2 :: " + m_hwInterop->name() + " texture map error");
                 }
             }
             if (!imageReady && !hasImage)


### PR DESCRIPTION
We don't need to mark error logs as translatable.
