### PR TITLE
YouTubeDL: Allow passing HTTP referrer in additional module parameters

### DIFF
--- a/src/qmplay2/YouTubeDL.cpp
+++ b/src/qmplay2/YouTubeDL.cpp
@@ -124,7 +124,7 @@ void YouTubeDL::addr(const QString &url, const QString &param, QString *streamUr
     QStringList paramList {"-e"};
     if (!param.isEmpty())
     {
-        paramList << "-f" << param;
+        paramList << (QUrl(param).host().isEmpty() ? "-f" : "--referer") << param;
     }
     else
     {


### PR DESCRIPTION
Hello @zaps166,
You have already allowed cookies from browsers (2c9d7c2), but sometimes that is not enough and you can still get a 403 error.
Some network streams require custom HTTP headers and this looks redundant for the media player. But the HTTP referrer can be easily extracted and can be used in additional module parameters.

This PR allows it and neatly extends the current QMPlay2 behavior.
I hope this will be useful. What do you think?