### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sudo dnf install qmplay2
 
 #### Easy installation on Slackware Linux
 
-- Run the following command: `slpkg -i QMPlay2`
+- Run the following command: `slpkg install QMPlay2`
 
 ## YouTube
 


### PR DESCRIPTION
The slpkg command line now uses Python's argparse for parsing, which means short options for commands are no longer available.