### PR TITLE
support the COMPOSER tag in audio files

### DIFF
--- a/src/modules/FFmpeg/FormatContext.cpp
+++ b/src/modules/FFmpeg/FormatContext.cpp
@@ -375,6 +375,8 @@ QList<QMPlay2Tag> FormatContext::tags() const
     {
         if (!(value = getTag(dict, "title")).isEmpty())
             tagList += {QString::number(QMPLAY2_TAG_TITLE), value};
+        if (!(value = getTag(dict, "composer")).isEmpty())
+            tagList += {QString::number(QMPLAY2_TAG_COMPOSER), value};
         if (!(value = getTag(dict, "artist")).isEmpty())
             tagList += {QString::number(QMPLAY2_TAG_ARTIST), value};
         if (!(value = getTag(dict, "album")).isEmpty())
@@ -1120,6 +1122,8 @@ StreamInfo *FormatContext::getStreamInfo(AVStream *stream) const
         if (streamsInfo.count() > 1)
         {
             streamInfo->title  = getTag(stream->metadata, "title");
+            if (!(value = getTag(stream->metadata, "composer")).isEmpty())
+                streamInfo->other_info += {QString::number(QMPLAY2_TAG_COMPOSER), value};
             streamInfo->artist = getTag(stream->metadata, "artist");
             if (!(value = getTag(stream->metadata, "album")).isEmpty())
                 streamInfo->other_info += {QString::number(QMPLAY2_TAG_ALBUM), value};

--- a/src/qmplay2/StreamInfo.cpp
+++ b/src/qmplay2/StreamInfo.cpp
@@ -41,6 +41,8 @@ QString StreamInfo::getTagName(const QString &tag)
             return tr("Language");
         case QMPLAY2_TAG_TITLE:
             return tr("Title");
+        case QMPLAY2_TAG_COMPOSER:
+            return tr("Composer");
         case QMPLAY2_TAG_ARTIST:
             return tr("Artist");
         case QMPLAY2_TAG_ALBUM:

--- a/src/qmplay2/StreamInfo.hpp
+++ b/src/qmplay2/StreamInfo.hpp
@@ -44,6 +44,7 @@ enum QMPlay2Tags
     QMPLAY2_TAG_DESCRIPTION, //should be as second
     QMPLAY2_TAG_LANGUAGE,
     QMPLAY2_TAG_TITLE,
+    QMPLAY2_TAG_COMPOSER,
     QMPLAY2_TAG_ARTIST,
     QMPLAY2_TAG_ALBUM,
     QMPLAY2_TAG_GENRE,
@@ -109,7 +110,7 @@ public:
     QByteArray getColorTrcName() const;
     QByteArray getColorSpaceName() const;
 
-    QByteArray codec_name, title, artist;
+    QByteArray codec_name, title, composer, artist;
     QByteArray codec_name_backup;
     QVector<QMPlay2Tag> other_info;
     bool is_default = true;


### PR DESCRIPTION
The information is shown between the track title and artist lines, which is an appropriation location at least for classical-style music
