### PR TITLE
Try not to access YT streams before they're available

### DIFF
--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -20,6 +20,7 @@
 
 #include <YouTubeDL.hpp>
 #include <LineEdit.hpp>
+#include <Functions.hpp>
 
 #include <QLoggingCategory>
 #include <QStringListModel>
@@ -46,7 +47,6 @@
 
 #include <QDateTime>
 #include <QDeadlineTimer>
-#include <unistd.h>
 
 Q_LOGGING_CATEGORY(youtube, "Extensions/YouTube")
 
@@ -1304,9 +1304,9 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
                 urlLanguages[url] = format[QStringLiteral("language")].toString();
                 urlNotes[url] = note;
             }
-            if (format.contains("available_at"))
+            if (format.contains(QStringLiteral("available_at")))
             {
-                auto available_at = format["available_at"].toDouble() * 1000.0;
+                auto available_at = format[QStringLiteral("available_at")].toDouble() * 1000.0;
                 qCDebug(youtube) << "url for format" << format["format_id"].toString() << "will be available at"
                     << QDateTime::fromMSecsSinceEpoch(available_at) << "so in" << (available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0 << "s";
                 if (available_at > latest_available_at)
@@ -1454,22 +1454,24 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
 
     if (latest_available_at > 0)
     {
-        const auto dt = int( (latest_available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0 + 0.5);
+        // The number of whole seconds until the "slowest" stream is promised to be available, plus 1
+        // This interval can be <=0 if the stream is already available!
+        const auto dt = int( (latest_available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0) + 1;
         if (dt > 0) {
             QMPlay2Core.logInfo(QString::asprintf("Waiting for %ds as required by YouTube", dt));
             // do an active wait; a less active clone of QTest::qWait():
-            auto remaining = dt * 1000;
+            auto remaining = dt * 1000.0;
             QDeadlineTimer timer(remaining, Qt::PreciseTimer);
             do
             {
                 QCoreApplication::processEvents(QEventLoop::AllEvents, remaining);
-                QCoreApplication::sendPostedEvents(Q_NULLPTR, QEvent::DeferredDelete);
+                QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
                 remaining = timer.remainingTime();
                 if (remaining <= 0)
                 {
                     break;
                 }
-                usleep(qMin(100, remaining) * 1000);
+                Functions::s_wait(qMin(100.0, remaining) / 1000.0);
                 remaining = timer.remainingTime();
             } while (remaining > 0);
         }

--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -44,6 +44,10 @@
 #include <QMenu>
 #include <QUrl>
 
+#include <QDateTime>
+#include <QDeadlineTimer>
+#include <unistd.h>
+
 Q_LOGGING_CATEGORY(youtube, "Extensions/YouTube")
 
 #define YOUTUBE_URL "https://www.youtube.com"
@@ -1271,6 +1275,8 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
 
     QHash<int, QPair<QStringList, QStringList>> itagsData;
 
+    double latest_available_at = 0.0;
+
     for (auto &&formatVal : formats)
     {
         const auto format = formatVal.toObject();
@@ -1297,6 +1303,16 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
             {
                 urlLanguages[url] = format[QStringLiteral("language")].toString();
                 urlNotes[url] = note;
+            }
+            if (format.contains("available_at"))
+            {
+                auto available_at = format["available_at"].toDouble() * 1000.0;
+                qCDebug(youtube) << "url for format" << format["format_id"].toString() << "will be available at"
+                    << QDateTime::fromMSecsSinceEpoch(available_at) << "so in" << (available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0 << "s";
+                if (available_at > latest_available_at)
+                {
+                    latest_available_at = available_at;
+                }
             }
         }
     }
@@ -1436,6 +1452,28 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
 
     result += o["description"].toString();
 
+    if (latest_available_at > 0)
+    {
+        const auto dt = int( (latest_available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0 + 0.5);
+        if (dt > 0) {
+            QMPlay2Core.logInfo(QString::asprintf("Waiting for %ds as required by YouTube", dt));
+            // do an active wait; a less active clone of QTest::qWait():
+            auto remaining = dt * 1000;
+            QDeadlineTimer timer(remaining, Qt::PreciseTimer);
+            do
+            {
+                QCoreApplication::processEvents(QEventLoop::AllEvents, remaining);
+                QCoreApplication::sendPostedEvents(Q_NULLPTR, QEvent::DeferredDelete);
+                remaining = timer.remainingTime();
+                if (remaining <= 0)
+                {
+                    break;
+                }
+                usleep(qMin(100, remaining) * 1000);
+                remaining = timer.remainingTime();
+            } while (remaining > 0);
+        }
+    }
     return result;
 }
 

--- a/src/modules/Extensions/YouTube.cpp
+++ b/src/modules/Extensions/YouTube.cpp
@@ -44,7 +44,6 @@
 #include <QLabel>
 #include <QMenu>
 #include <QUrl>
-
 #include <QDateTime>
 #include <QDeadlineTimer>
 
@@ -1307,8 +1306,12 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
             if (format.contains(QStringLiteral("available_at")))
             {
                 auto available_at = format[QStringLiteral("available_at")].toDouble() * 1000.0;
-                qCDebug(youtube) << "url for format" << format["format_id"].toString() << "will be available at"
-                    << QDateTime::fromMSecsSinceEpoch(available_at) << "so in" << (available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0 << "s";
+                double dt = (available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0;
+                if (dt < 0)
+                {
+                    qCDebug(youtube) << "url for format" << format["format_id"].toString() << "will be available at"
+                        << QDateTime::fromMSecsSinceEpoch(available_at) << "so in" << dt << "s";
+                }
                 if (available_at > latest_available_at)
                 {
                     latest_available_at = available_at;
@@ -1456,16 +1459,17 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
     {
         // The number of whole seconds until the "slowest" stream is promised to be available, plus 1
         // This interval can be <=0 if the stream is already available!
-        const auto dt = int( (latest_available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0) + 1;
-        if (dt > 0) {
-            QMPlay2Core.logInfo(QString::asprintf("Waiting for %ds as required by YouTube", dt));
+        const auto dt = static_cast<int>((latest_available_at - QDateTime::currentMSecsSinceEpoch()) / 1000.0) + 1;
+        if (dt > 0 && !youTubeDL.isAborted() )
+        {
+            const auto waitMsg = QString::asprintf("Waiting for %ds as required by YouTube", dt);
+            qCInfo(youtube) << waitMsg;
+            emit QMPlay2Core.statusBarMessage(waitMsg, dt * 1000);
             // do an active wait; a less active clone of QTest::qWait():
             auto remaining = dt * 1000.0;
             QDeadlineTimer timer(remaining, Qt::PreciseTimer);
             do
             {
-                QCoreApplication::processEvents(QEventLoop::AllEvents, remaining);
-                QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
                 remaining = timer.remainingTime();
                 if (remaining <= 0)
                 {
@@ -1473,7 +1477,10 @@ QStringList YouTube::getYouTubeVideo(const QString &param, const QString &url, I
                 }
                 Functions::s_wait(qMin(100.0, remaining) / 1000.0);
                 remaining = timer.remainingTime();
-            } while (remaining > 0);
+            } while (remaining > 0 && !youTubeDL.isAborted());
+            if (remaining > 0) {
+                QMPlay2Core.logInfo(QStringLiteral("Stopped"));
+            }
         }
     }
     return result;


### PR DESCRIPTION
YouTube (now?) provides an `available_at` timestamp for streams, and it seems that accessing them before that time can result in a 403 Forbidden error.

This commit introduces a simple fix that determines which of the streams of a given video is available last, and then does a non- blocking wait before attempting to open the selected streams. The wait is signalled via a statusbar message.

There are no side-effects other than that the wait is imposed also when pasting a YT video link directly into the playlist, apparently because this operation involves starting playback. This should be avoidable but will require more work.

#Closes: #1027